### PR TITLE
Database::get_ids_by_field_values() should process %opts fixing #32

### DIFF
--- a/perl_lib/EPrints/Database.pm
+++ b/perl_lib/EPrints/Database.pm
@@ -2610,7 +2610,7 @@ sub get_ids_by_field_values
 {
 	my( $self, $field, $dataset, %opts ) = @_;
 
-	return $dataset->prepare_search->perform_distinctby( [$field] );
+	return $dataset->prepare_search( %opts )->perform_distinctby( [$field] );
 }
 
 =item @events = $db->dequeue_events( $n )


### PR DESCRIPTION
Note that customer previously called:

```
my $full_text_status = $session->get_repository->get_dataset( "eprint" )->get_field( "full_text_status" );
my $filters = [ { fields=>[ $full_text_status ], value=>$opt }];
my $vref = $field->get_ids_by_value( $session, $ds, filters=>$filters );
```

and they had to change this to:

```
my $filters = [ { meta_fields=>[ "full_text_status" ], value=>$opt }];
my $vref = $field->get_ids_by_value( $session, $ds, filters=>$filters );
```

in order for the fix to work.
