### PR TITLE
Update Local.pm

### DIFF
--- a/perl_lib/EPrints/Plugin/Storage/Local.pm
+++ b/perl_lib/EPrints/Plugin/Storage/Local.pm
@@ -214,7 +214,7 @@ sub _filename
 	if( !defined $filename )
 	{
 		$filename = $fileobj->get_value( "filename" );
-		$filename = escape_filename( $filename );
+		$filename = $self->escape_filename( $filename );
 	}
 
 	my $in_file;
@@ -251,7 +251,7 @@ sub _filename
 
 sub escape_filename
 {
-	my( $filename ) = @_;
+	my( $self, $filename ) = @_;
 
 	# $filename is UTF-8
 	$filename =~ s# /\.+ #/_#xg; # don't allow hiddens


### PR DESCRIPTION
Was 'escape_filename' written as a function instead of a method on purpose, or was it an oversight?

This causes problems when trying to sub-class this to create another local flat-file storage area.
