### PR TITLE
Add an option to repo->redirect() to modify the HTTP status code

### DIFF
--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -4193,17 +4193,8 @@ sub clone_for_me
 
 Redirects the browser to $url.
 
-If %opts contains a 'mode', it is used to modify the semantics of
-the redirection:
-
-    value  alias       HTTP Status
-    301    permanent   301 Moved Permanently
-    302    temporary   302 Found
-    303    other       303 See Other
-    307    temporary!  307 Temporary Redirect
-    308    permanent!  308 Permanent Redirect  (experimental)
-
-By default it issues a 302 temporary redirection.
+If %opts contains a 'status_code', it is used as the status code of
+the HTTP response.  By default it issues a 302 temporary redirection.
 
 =end InternalDoc
 
@@ -4221,45 +4212,9 @@ sub redirect
 		return;
 	}
 
-	my $status = 302, $message = "Moved";
-	if( exists $opts{mode} )
-	{
-		SWITCH: for( $opts{mode} )
-		{
-			if( /^(301|permanent)$/i )
-			{
-				$status = 301; $message = 'Moved Permanently';
-				delete $opts{mode};
-				last SWITCH;
-			}
-			if( /^(302|temporary)$/i )
-			{
-				$status = 302; $message = 'Found';
-				delete $opts{mode};
-				last SWITCH;
-			}
-			if( /^(303|other)$/i )
-			{
-				$status = 303; $message = 'See Other';
-				delete $opts{mode};
-				last SWITCH;
-			}
-			if( /^(307|temporary!)$/i )
-			{
-				$status = 307; $message = 'Temporary Redirect';
-				delete $opts{mode};
-				last SWITCH;
-			}
-			if( /^(308|permanent!)$/i )
-			{
-				$status = 308; $message = 'Permanent Redirect';
-				delete $opts{mode};
-				last SWITCH;
-			}
-		}
-	}
+	my $status = delete $opts{status_code} || 302;
 
-	EPrints::Apache::AnApache::send_status_line( $self->{"request"}, $status, $message );
+	EPrints::Apache::AnApache::send_status_line( $self->{"request"}, $status, );
 	EPrints::Apache::AnApache::header_out( 
 		$self->{"request"},
 		"Location",


### PR DESCRIPTION
Allows the user to override the HTTP Status Code used when issuing a redirect.

Default uses 302; modification allows:
- 301 -- permanent, may GET the alternate location (even if the request was a POST)
- 302 -- temporary, may GET the alternate location
- 303 -- a related resource, _not_ an alternate location of the requested resource
- 307 -- temporary, _must_ GET the alternate location (even if the request was a POST)
- 308 -- permanent, _must_ GET the alternate location (experimental/draft)
