### PR TITLE
Added an inbox review screen

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Inbox.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Inbox.pm
@@ -1,0 +1,64 @@
+=head1 NAME
+
+EPrints::Plugin::Screen::Inbox
+
+=cut
+
+
+package EPrints::Plugin::Screen::Inbox;
+
+use EPrints::Plugin::Screen::Listing;
+
+@ISA = ( 'EPrints::Plugin::Screen::Review'); 
+
+use strict;
+
+sub properties_from
+{
+	my( $self ) = @_;
+
+	my $processor = $self->{processor};
+	my $repo = $self->{session};
+
+	$processor->{dataset} = $repo->dataset( "inbox" );
+	$processor->{columns_key} = "screen.review.columns";
+
+	$self->SUPER::properties_from;
+}
+
+sub get_filters
+{
+	my( $self ) = @_;
+
+	return(
+		{ meta_fields => [qw( eprint_status )], value => "inbox", },
+	);
+}
+
+1;
+
+=for COPYRIGHT BEGIN
+
+Copyright 2000-2011 University of Southampton.
+
+=for COPYRIGHT END
+
+=for LICENSE BEGIN
+
+This file is part of EPrints L<http://www.eprints.org/>.
+
+EPrints is free software: you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+EPrints is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with EPrints.  If not, see L<http://www.gnu.org/licenses/>.
+
+=for LICENSE END
+


### PR DESCRIPTION
This might not be the right way to add this display, but it is a feature requested to me by my repository administrators: How to cope with the objects left lingering by users in their "User Area" for months, sometimes empty? Or how to recognize if users just forgot to click on "Deposit now" and left a seemingly complete object just sitting? This view is _very_ similar to the Review one, just chainging the filtering.
