### PR TITLE
allow misc. namespaces in XHTML

### DIFF
--- a/perl_lib/EPrints/XHTML.pm
+++ b/perl_lib/EPrints/XHTML.pm
@@ -450,7 +450,7 @@ sub _to_xhtml
 		# set the default XHTML namespace for the root <html/> element
 		if( $tagname eq "html" )
 		{
-			push @n, " xmlns=\"$NS_XHTML\"";
+			push @n, ' xmlns="', $NS_XHTML, '"';
 			$seen->{'xmlns'} = 1;
 		}
 

--- a/perl_lib/EPrints/XHTML.pm
+++ b/perl_lib/EPrints/XHTML.pm
@@ -408,7 +408,10 @@ sub _to_xhtml
 	my @n = ();
 	if( $type == XML_ELEMENT_NODE )
 	{
-		my $tagname = $node->localName; # ignore prefixes
+		my $tagname = $node->nodeName; # includes NS prefix
+
+		# strip namespaces that are no longer relevant or required in xhtml
+		$tagname =~ s/^(xhtml|ep[pc])://;
 
 		$tagname = lc($tagname);
 
@@ -418,14 +421,19 @@ sub _to_xhtml
 		if( $tagname eq "html" )
 		{
 			push @n, ' xmlns="http://www.w3.org/1999/xhtml"';
+			$seen->{'xmlns'} = 1;
 		}
 
 		foreach my $attr ( $node->attributes )
 		{
 			my $name = $attr->nodeName;
-			# strip all namespace definitions and prefixes
-			next if $name =~ /^xmlns/;
-			$name =~ s/^.+://;
+			# strip epp/epc namespace definitions
+			next if $name =~ /^xmlns:ep[pc]$/;
+			# dump epp/epc-namespaced attributes
+			next if $attr->prefix =~ /^ep[pc]$/;
+
+			# clean up xhtml-namespaced attributes
+			$name =~ s/^xhtml://;
 
 			next if( exists $seen->{$name} );
 			$seen->{$name} = 1;

--- a/perl_lib/EPrints/XHTML.pm
+++ b/perl_lib/EPrints/XHTML.pm
@@ -106,7 +106,6 @@ use strict;
 %EPrints::XHTML::COMPRESS_TAG = map { $_ => 1 } @EPrints::XHTML::COMPRESS_TAGS;
 
 # XML namespace URIs
-my $NS_XMLNS = 'http://www.w3.org/2000/xmlns/';
 my $NS_XHTML = 'http://www.w3.org/1999/xhtml';
 my $NS_EPP   = 'http://eprints.org/ep3/phrase';
 my $NS_EPC   = 'http://eprints.org/ep3/control';
@@ -457,21 +456,22 @@ sub _to_xhtml
 		# specially handle namespace attributes
 		foreach my $ns ( $attr->getNamespaces )
 		{
-			# include all xmlns:foo definitions except epp|epc
+			# include all xmlns:* definitions except epp|epc
 			my $nsuri = $ns->getValue;
 			if( !( $nsuri eq $NS_EPP || $nsuri eq $NS_EPC ) )
 			{
 				my $value = _attr_value( $nsuri );
-				push @n, ' ', $ns->nodeName, '="', $value, '"';
+				push @n, ' ', $ns->name, '="', $value, '"';
+				$seen->{$ns->name} = 1;
 			}
 		}
 
 		# now handle all regular attributes
 		foreach my $attr ( $node->attributes )
 		{
-			# drop attributes in the xmlns|epp|epc namespaces
+			# drop attributes in the epp|epc namespaces
 			my $nsuri = $attr->namespaceURI;
-			next if $nsuri && ( $nsuri eq $NS_XMLNS || $nsuri eq $NS_EPP || $nsuri eq $NS_EPC );
+			next if $nsuri && ( $nsuri eq $NS_EPP || $nsuri eq $NS_EPC );
 
 			# get the sanitised attribute name
 			my $name = _name_of( $attr );


### PR DESCRIPTION
**This PR is intended to open a _discussion_ on options for allowing namespaces in generated XHTML.**

The `xml:lang` attribute is [required on the html element](http://www.w3.org/TR/xhtml1/#C_7) for XHTML documents and [correct language specification](http://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-doc-lang-id.html) is also a Level A accessibility requirements for WCAG 2.0

This experimental change preserves all namespaces but those with the epp: and epc: prefixes in generated XHTML, and mangles the xhtml: prefix.

**Note well:** a proper implementation would have to _at least_ inspect the namespace definitions to discover the prefixes for namespaces whose URIs are `http://eprints.org/ep3/phrase` and `http://eprints.org/ep3/control`, rather than assuming epp: and epc: