### PR TITLE
Update render_possible_doi to match more valid DOIs

### DIFF
--- a/perl_lib/EPrints/Extras.pm
+++ b/perl_lib/EPrints/Extras.pm
@@ -305,9 +305,8 @@ sub render_possible_doi
 	$value = "" unless defined $value;
 	$value =~ s!^http://dx\.doi\.org/!!;
 
-	if( $value !~ m!^(doi:)?10\.\d{4}/! ) { return $session->make_text( $value ); }
-	
-	$value =~ s!^doi:!!;
+	if( $value !~ m!^(?:(?:doi:?)?\s*)(10(\.[^./]+)+/.+)$!i ) { return $session->make_text( $value ); }
+	$value = $1;
 
 	my $url = "http://dx.doi.org/$value";
 	my $link = $session->render_link( $url, "_blank" ); 


### PR DESCRIPTION
Possible fix for #139, although I'm unsure about the nested non-capturing groups in the RE, and if the '$value = $1' is the best way of doing this (it does seem to work though).

Based on ~7,000 id_numbers, of which ~6,000 were DOIs, which included variations like:
DOI: 10.xxxx
doi 10.xxxx
10.xxxx
