### PR TITLE
Removed duplicate updates to make dry-run work

### DIFF
--- a/bin/lift_embargos
+++ b/bin/lift_embargos
@@ -150,16 +150,12 @@ $list->map( sub {
 		$doc->set_value( "date_embargo", undef );
 		$doc->commit( 1 ); # pass force through to parent eprint
 		$eprint->generate_static;
-	}
-	$doc->set_value( "security", "public" );
-	$doc->set_value( "date_embargo", undef );
-	$doc->commit( 1 );
-	$eprint->commit( 1 );
-	$eprint->generate_static;
-	# post-processing, eg. send notification of embargo expiry
-	if( $session->can_call( "notify_embargo_expiry" ) )
-	{
-		$session->call( "notify_embargo_expiry", $eprint, $doc );
+
+		# post-processing, eg. send notification of embargo expiry
+		if( $session->can_call( "notify_embargo_expiry" ) )
+		{
+			$session->call( "notify_embargo_expiry", $eprint, $doc );
+		}
 	}
 } );
 


### PR DESCRIPTION
Extra calls to update and commit document removed. All 'active' calls are now in the 'if not dry-run' block, including the call to 'notify_embargo_expiry'.
