### PR TITLE
Simple search should remove short words

### DIFF
--- a/perl_lib/EPrints/Search/Field.pm
+++ b/perl_lib/EPrints/Search/Field.pm
@@ -523,8 +523,13 @@ sub split_value
 			"indexing",
 			"freetext_always_words"
 		);
+	my $freetext_min_word_size = $self->{repository}->config(
+			"indexing",
+			"freetext_min_word_size"
+		);
 	@values = grep {
 			EPrints::Utils::is_set( $_ ) &&
+			length $_ >= $freetext_min_word_size &&
 			($freetext_always_words->{lc($_)} ||
 			!$freetext_stop_words->{lc($_)})
 		} @values;


### PR DESCRIPTION
Indexing doesn't include words less than $freetext_min_word_size.
If these are not removed from the (non-Xapian) simple search, no results are found for searches than contain short words e.g. 'cake or death' would not find something called 'cake or death', whereas 'cake death' would.
This should make the simple search match the indexing pattern.
