### PR TITLE
amended DOI import plugin to ignore DOIs already present

### DIFF
--- a/lib/defaultcfg/cfg.d/plugins.pl
+++ b/lib/defaultcfg/cfg.d/plugins.pl
@@ -58,4 +58,8 @@
 # You should replace this with your own CrossRef account username and password.
 
 $c->{plugins}->{"Import::DOI"}->{params}->{pid} = "ourl_eprintsorg:eprintsorg";
+# set the default options for the DOI import plugin - change these to reflect your
+# own repository requirements
+$c->{plugins}->{"Import::DOI"}->{params}->{doi_field} = "id_number";
+$c->{plugins}->{"Import::DOI"}->{params}->{use_prefix} = 1;
 

--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -3150,6 +3150,7 @@ PY = 2006 and OG = (Cambridge)<br />
 	<epp:phrase id="Plugin/Import/DefaultXML:file_imports_disabled">Attempt to import eprint with document data expressed as a local filename. This is a security hole in normal use, and is disabled. It *is* useful when bulk importing and may be enabled by setting enable_file_imports.</epp:phrase>
 	<epp:phrase id="Plugin/Import/DefaultXML:file_not_exists">Could not locate file for import: <epc:pin name="href" />.</epp:phrase>
 	<epp:phrase id="Plugin/Import/DOI:invalid_doi">Unrecognised or invalid doi: <epc:pin name="doi" />.<br />Remote service said: <tt><epc:pin name="msg"/></tt></epp:phrase>
+	<epp:phrase id="Plugin/Import/DOI:duplicate_doi"><strong>Duplicate DOI: <epc:pin name="doi" /></strong>.<br />This DOI already exists in the repository: <br /><epc:pin name="msg"/></epp:phrase>
 
 	<!-- Convert plugins -->
 


### PR DESCRIPTION
Added a phrase to system.xml and 2 config values to
plugins.pl to allow control of the database field holding the DOI and
how it deals with the "doi:" prefix on the value to account for local
differences.
