### PR TITLE
Corrects documentation for eprint_render function

### DIFF
--- a/lib/defaultcfg/cfg.d/eprint_render.pl
+++ b/lib/defaultcfg/cfg.d/eprint_render.pl
@@ -18,19 +18,28 @@ $c->{summary_page_metadata} = [qw/
 
 
 ######################################################################
+=pod
+
+=over
 
 =item $xhtmlfragment = eprint_render( $eprint, $repository, $preview )
 
 This subroutine takes an eprint object and renders the XHTML view
 of this eprint for public viewing.
 
-Takes two arguments: the L<$eprint|EPrints::DataObj::EPrint> to render and the current L<$repository|EPrints::Session>.
+Takes two arguments: the L<$eprint|EPrints::DataObj::EPrint> to render
+and the current L<$repository|EPrints::Session>.
 
-Returns three XHTML DOM fragments (see L<EPrints::XML>): C<$page>, C<$title>, (and optionally) C<$links>.
+Returns an array ( C<$page>, C<$title>[, C<$links>[, C<$template>]] )
+where C<$page>, C<$title> and C<$links> are XHTML DOM objects and
+C<$template> is a string containing the name of the template to use
+for this page.
 
 If $preview is true then this is only being shown as a preview.
 (This is used to stop the "edit eprint" link appearing when it makes
 no sense.)
+
+=back
 
 =cut
 


### PR DESCRIPTION
Updates the documentation for the eprint_render repository config function in the default configuration file to show that a template name can be returned as per http://wiki.eprints.org/w/Abstract_page_template.