### PR TITLE
Makes the names of the output files of Plugin::Convert::PlainText unique...

### DIFF
--- a/perl_lib/EPrints/Plugin/Convert/PlainText.pm
+++ b/perl_lib/EPrints/Plugin/Convert/PlainText.pm
@@ -111,11 +111,14 @@ sub export
 	return () unless defined $cmd_id;
 	
 	my @txt_files;
+	my $i = 0; # iterable value to append to target filenames to
+	           # make them unique
 	foreach my $file ( @{($doc->get_value( "files" ))} )
 	{
 		my $filename = $file->get_value( "filename" );
 		my $tgt = $filename;
-		next unless $tgt =~ s/\.$file_extension$/\.txt/;
+		$i++;
+		next unless $tgt =~ s/\.$file_extension$/\.$i\.txt/;
 		$tgt =~ s/^.*\///; # strip directories
 		my $outfile = "$dir/$tgt";
 		


### PR DESCRIPTION
... so it doesn't overwrite them. This prevents `Plugin::Convert::IndexCodes` calling `die` in some circumstances, e.g., when an HTML document has multiple files with the same name, such as /index.html and /about/index.html.

This fix is for 3.3, a fix for master will follow.
