### PR TITLE
Makes the names of the output files of Plugin::Convert::PlainText unique...

### DIFF
--- a/perl_lib/EPrints/Plugin/Convert/PlainText.pm
+++ b/perl_lib/EPrints/Plugin/Convert/PlainText.pm
@@ -111,11 +111,14 @@ sub export
 	return () unless defined $cmd_id;
 	
 	my @txt_files;
+	my $i = 0; # iterable value to append to target filenames to
+	           # make them unique
 	foreach my $file ( @{($doc->get_value( "files" ))} )
 	{
 		my $filename = $file->get_value( "filename" );
 		my $tgt = $filename;
-		next unless $tgt =~ s/\.$file_extension$/\.txt/;
+		$i++;
+		next unless $tgt =~ s/\.$file_extension$/\.$i\.txt/;
 		$tgt =~ s/^.*\///; # strip directories
 		my $outfile = "$dir/$tgt";
 		


### PR DESCRIPTION
... so it doesn't overwrite them.

Same as #277 for master
