### PR TITLE
Fix typo in css keyword (list-stlye -> list-style)

### DIFF
--- a/lib/static/oai2.xsl
+++ b/lib/static/oai2.xsl
@@ -143,7 +143,7 @@ ul.quicklinks {
 ul.quicklinks li {
 	font-size: 80%;
 	display: inline;
-	list-stlye: none;
+	list-style: none;
 	font-family: sans-serif;
 }
 p.intro {


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>