### PR TITLE
Added support for proxy to connect to bazaar

### DIFF
--- a/perl_lib/EPrints/EPM/Source.pm
+++ b/perl_lib/EPrints/EPM/Source.pm
@@ -21,6 +21,12 @@ sub new
 
 	$self{ua} = LWP::UserAgent->new;
 	$self{ua}->env_proxy;
+	my $repo = $self{repository};
+
+        if ( $repo->config( "proxy" ))
+        {
+          $self{ua}->proxy(['http', 'https', 'ftp'], $repo->config( "proxy" ));
+        }
 
 	return bless \%self, $class;
 }


### PR DESCRIPTION
Proxy should be coherent along the whole platform. This fix the connection with the EPM library and look for 
$c->{proxy} = 'http://xxx.xxx.xxx:8080';
I propose to have a method Proxy.pm under Utils to centralize proxy handling
