### PR TITLE
Add documented parameters to 'toform' call

### DIFF
--- a/lib/static/oai2.xsl
+++ b/lib/static/oai2.xsl
@@ -143,7 +143,7 @@ ul.quicklinks {
 ul.quicklinks li {
 	font-size: 80%;
 	display: inline;
-	list-stlye: none;
+	list-style: none;
 	font-family: sans-serif;
 }
 p.intro {

--- a/perl_lib/EPrints/MetaField.pm
+++ b/perl_lib/EPrints/MetaField.pm
@@ -483,7 +483,7 @@ sub render_input_field
 
 	if( defined $self->{toform} )
 	{
-		$value = $self->call_property( "toform", $value, $session );
+		$value = $self->call_property( "toform", $value, $session, $obj, $basename );
 	}
 
 	if( defined $self->{render_input} )

--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -631,6 +631,10 @@ sub remote_ip
                 $ip = $r->connection->client_ip;
         }
 
+	if( !EPrints::Utils::is_set( $ip ) && $r->connection->can( "remote_ip" ) )
+	{
+		$ip = $r->connection->remote_ip;
+	}
         return $ip;
 }
 


### PR DESCRIPTION
Added $obj and $basename to the call to the 'toform' function as suggested by the wiki documentation for EPrints::Metafield.  Allows more complex multi-field manipulation for field values presented in the workflow.
Resolves my issue #302 