### PR TITLE
explicit phrases for later/earlier versions of eprints

### DIFF
--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -1388,7 +1388,7 @@ For more information see <a href="http://eprints.org/d/?keyword=MetaFields">Meta
     <epp:phrase id="lib/eprint:eprint_gone_title">Item Removed</epp:phrase>
     <epp:phrase id="lib/eprint:eprint_gone"><p>You seem to be attempting to access an item that has been removed from the repository.</p></epp:phrase>
     <epp:phrase id="lib/eprint:later_version"><p>There is a later version of the item you are trying to access:<br/><epc:pin name="citation"/></p></epp:phrase>
-    <epp:phrase id="lib/eprint:earlier_version"><p>There is an earlier version of the item you are trying to access:<br/><epc:pin name="citation"/></p></epp:phrase>
+    <epp:phrase id="lib/eprint:replaced_version"><p>There is an earlier version of the item you are trying to access:<br/><epc:pin name="citation"/></p></epp:phrase>
     <epp:phrase id="lib/eprint:curr_disp"><strong>[Currently Displayed]</strong></epp:phrase>
     <epp:phrase id="lib/eprint:not_locked">Not currently locked.</epp:phrase>
     <epp:phrase id="lib/eprint:locked">Locked by <epc:pin name='locked_by' /> until <epc:pin name='locked_until' /></epp:phrase>

--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -1388,7 +1388,7 @@ For more information see <a href="http://eprints.org/d/?keyword=MetaFields">Meta
     <epp:phrase id="lib/eprint:eprint_gone_title">Item Removed</epp:phrase>
     <epp:phrase id="lib/eprint:eprint_gone"><p>You seem to be attempting to access an item that has been removed from the repository.</p></epp:phrase>
     <epp:phrase id="lib/eprint:later_version"><p>There is a later version of the item you are trying to access:<br/><epc:pin name="citation"/></p></epp:phrase>
-    <epp:phrase id="lib/eprint:replaced_version"><p>There is an alternative version of the item you are trying to access:<br/><epc:pin name="citation"/></p></epp:phrase>
+    <epp:phrase id="lib/eprint:earlier_version"><p>There is an earlier version of the item you are trying to access:<br/><epc:pin name="citation"/></p></epp:phrase>
     <epp:phrase id="lib/eprint:curr_disp"><strong>[Currently Displayed]</strong></epp:phrase>
     <epp:phrase id="lib/eprint:not_locked">Not currently locked.</epp:phrase>
     <epp:phrase id="lib/eprint:locked">Locked by <epc:pin name='locked_by' /> until <epc:pin name='locked_until' /></epp:phrase>

--- a/perl_lib/EPrints/DataObj/EPrint.pm
+++ b/perl_lib/EPrints/DataObj/EPrint.pm
@@ -1513,7 +1513,7 @@ sub render
 		$dom = $self->{session}->make_doc_fragment;
 		$dom->appendChild( $self->{session}->html_phrase( 
 			"lib/eprint:eprint_gone" ) );
-		my( $replacement, $successor );
+		my( $replacement, $antecendent );
 		my $succeeds = $self->{dataset}->field( "succeeds" );
 		my $later = $self->later_in_thread( $succeeds );
 		if( $later->count > 0 )
@@ -1526,7 +1526,7 @@ sub render
 		}
 		if( $self->is_set( "succeeds" ) )
 		{
-			$successor = $self->{session}->eprint( $self->value( "succeeds" ) );
+			$antecendent = $self->{session}->eprint( $self->value( "succeeds" ) );
 		}
 		if( defined $replacement && $replacement->value( "eprint_status" ) eq "archive" )
 		{
@@ -1535,12 +1535,12 @@ sub render
 					"lib/eprint:later_version",
 					citation => $replacement->render_citation_link ) );
 		}
-		elsif( defined $successor && $successor->value( "eprint_status" ) eq "archive" )
+		elsif( defined $antecendent && $antecendent->value( "eprint_status" ) eq "archive" )
 		{
 			$dom->appendChild(
 				$self->{session}->html_phrase(
 					"lib/eprint:earlier_version",
-					citation => $successor->render_citation_link ) );
+					citation => $antecendent->render_citation_link ) );
 		}
 	}
 	else

--- a/perl_lib/EPrints/DataObj/EPrint.pm
+++ b/perl_lib/EPrints/DataObj/EPrint.pm
@@ -1513,27 +1513,34 @@ sub render
 		$dom = $self->{session}->make_doc_fragment;
 		$dom->appendChild( $self->{session}->html_phrase( 
 			"lib/eprint:eprint_gone" ) );
-		my $replacement;
+		my( $replacement, $successor );
 		my $succeeds = $self->{dataset}->field( "succeeds" );
 		my $later = $self->later_in_thread( $succeeds );
 		if( $later->count > 0 )
 		{
 			$replacement = $later->item( 0 );
 		}
-		elsif( $self->is_set( "succeeds" ) )
-		{
-			$replacement = $self->{session}->eprint( $self->value( "succeeds" ) );
-		}
 		elsif( $self->{dataset}->has_field( "replacedby" ) && $self->is_set( "replacedby" ) ) ##backward compatibility for repository upgraded from older version, which had replacedby. 
 		{
 			$replacement = $self->{session}->eprint( $self->value( "replacedby" ) );
 		}
+		if( $self->is_set( "succeeds" ) )
+		{
+			$successor = $self->{session}->eprint( $self->value( "succeeds" ) );
+		}
 		if( defined $replacement && $replacement->value( "eprint_status" ) eq "archive" )
 		{
-			$dom->appendChild( 
-				$self->{session}->html_phrase( 
-					"lib/eprint:replaced_version", 
+			$dom->appendChild(
+				$self->{session}->html_phrase(
+					"lib/eprint:later_version",
 					citation => $replacement->render_citation_link ) );
+		}
+		elsif( defined $successor && $successor->value( "eprint_status" ) eq "archive" )
+		{
+			$dom->appendChild(
+				$self->{session}->html_phrase(
+					"lib/eprint:earlier_version",
+					citation => $successor->render_citation_link ) );
 		}
 	}
 	else

--- a/perl_lib/EPrints/DataObj/EPrint.pm
+++ b/perl_lib/EPrints/DataObj/EPrint.pm
@@ -1539,7 +1539,7 @@ sub render
 		{
 			$dom->appendChild(
 				$self->{session}->html_phrase(
-					"lib/eprint:earlier_version",
+					"lib/eprint:replaced_version",
 					citation => $antecendent->render_citation_link ) );
 		}
 	}


### PR DESCRIPTION
Clean up the link rendering for replacedby/succeeds relationships, explicitly differentiating links to newer vs earlier/outdated records.