### PR TITLE
Fix subjects/divisions being displayed in all languages after upgrade to 3.3.13

### DIFF
--- a/perl_lib/EPrints/DataObj/Subject.pm
+++ b/perl_lib/EPrints/DataObj/Subject.pm
@@ -952,8 +952,7 @@ sub render_description
 {
 	my( $self ) = @_;
 
-	# EPrints Services/sf2 2011-12-13 - render 'name_name' otherwise it will render 'name_name' and 'name_sortvalue'
-	return $self->render_value( "name_name" );
+	return $self->render_value( "name" );
 }
 
 

--- a/perl_lib/EPrints/MetaField/Multilang.pm
+++ b/perl_lib/EPrints/MetaField/Multilang.pm
@@ -89,7 +89,8 @@ sub render_value
 	$value = $self->lang_value( undef, $value )
 		if $self->property( "multiple" );
 
-	if( @$f > 2 ) # value + lang
+    # always render sub_name
+	if( 0 && @$f > 2 ) # value + lang
 	{
 		return $self->render_single_value( $session, $value );
 	}


### PR DESCRIPTION
This should fix #295 - apply the changes and regenerate subject/division view menus.