### PR TITLE
Log 304 responses to be COUNTER compliant

### DIFF
--- a/perl_lib/EPrints/Apache/LogHandler.pm
+++ b/perl_lib/EPrints/Apache/LogHandler.pm
@@ -142,8 +142,8 @@ sub document
 {
 	my( $r ) = @_;
 
-	# e.g. ignore 304 NOT MODIFIED
-	if( $r->status != 200 )
+	# COUNTER compliance specifies 200 and 304
+	if( $r->status != 200 && $r->status != 304 )
 	{
 		return DECLINED;
 	}


### PR DESCRIPTION
Fixes #308 
Could result in step-change on access stats, as 304 responses AND 200 responses will get an entry in the Access table.
