### PR TITLE
Modified thesis_type field test data to match repo default config

### DIFF
--- a/testdata/bin/import_rand_data
+++ b/testdata/bin/import_rand_data
@@ -205,7 +205,7 @@ for(1..$total)
 		publication => rand_publication(),
 		book_title => ($type eq "book_section" ? rand_title() : undef),
 		publisher => ($type =~ /^book/ ? rand_publisher() : undef),
-		thesis_type => ($type eq "thesis" ? "phd" : undef),
+		thesis_type => ($type eq "thesis" ? "doctoral" : undef),
 		institution => rand_institution(),
 		documents => rand_documents(),
 	};


### PR DESCRIPTION
Ensures `thesis_type` data from `import_rand_data` matches a value from the namedset in default config and avoids copious undefined phrase warnings.