### PR TITLE
Stops checking of SSL certificate during SWORD unit tests

### DIFF
--- a/tests/84_sword.pl
+++ b/tests/84_sword.pl
@@ -34,7 +34,7 @@ $secure_url->path( $repo->config( "https_root" ) );
 my $data = "Hello, World!";
 my $atom_data = join '', <DATA>;
 
-my $ua = MyUserAgent->new;
+my $ua = MyUserAgent->new( ssl_opts => { verify_hostname => 0 } );
 $ua->credentials( $base_url->host_port, "*", "admin", "admin" );
 $ua->credentials( $secure_url->host_port, "*", "admin", "admin" );
 


### PR DESCRIPTION
I assume that many if not most development instances of EPrints won't have a valid SSL certificate and thus will fail the SWORD unit tests. Seems better to allow an invalid cert and test SWORD properly.