### PR TITLE
Removes broken test searching nonexistent issues dataset

### DIFF
--- a/tests/30_search.pl
+++ b/tests/30_search.pl
@@ -1,6 +1,6 @@
 use strict;
 use utf8;
-use Test::More tests => 36;
+use Test::More tests => 35;
 
 BEGIN { use_ok( "EPrints" ); }
 BEGIN { use_ok( "EPrints::Test" ); }
@@ -422,27 +422,6 @@ $searchexp->add_field(
 $list = eval { $searchexp->perform_search };
 
 ok(defined($list) && $list->count > 0, "search multiple field".&describe($searchexp).&sql($searchexp));
-
-
-my $issue = $sample_eprint->create_subdataobj( 'item_issues', {
-	type => "tests/30_search",
-	status => "resolved",
-});
-$issue = $session->dataset( 'issue' )->dataobj( "tests/30_search" )
-	if !defined $issue;
-
-$searchexp = EPrints::Search->new(
-	session => $session,
-	dataset => $dataset,
-);
-
-$searchexp->add_field( $session->dataset( 'issue' )->field( "status" ), "resolved" );
-
-$list = eval { $searchexp->perform_search };
-
-ok(defined($list) && $list->count > 0, "subobject join_path".&describe($searchexp).&sql($searchexp));
-
-$issue->remove if defined $issue;
 
 SKIP:
 {


### PR DESCRIPTION
This test is about testing searching of objects and subobjects and tries to create an issues subobject for an eprint.  Issues aren't subobjects, however, just compound fields so this fails.  The test could potentially be replaced with a search over the documents subobjects but other tests of this type already exist so I figured the broken one may as well be just removed.