### PR TITLE
Recommeded host for DOI links has changed

### DIFF
--- a/perl_lib/EPrints/Extras.pm
+++ b/perl_lib/EPrints/Extras.pm
@@ -319,7 +319,7 @@ sub render_possible_doi
 		return $session->make_text( $value );
 	}
 
-	my $url = "http://dx.doi.org/$value";
+	my $url = "http://doi.org/$value";
 	my $link = $session->render_link( $url, "_blank" ); 
 	$link->appendChild( $session->make_text( $value ) );
 	return $link; 


### PR DESCRIPTION
From: http://www.doi.org/doi_handbook/3_Resolution.html#3.7.3 preference is to use doi.org, rather than dx.doi.org
