### PR TITLE
Fix for OAI-PMH to report eprints that have been live but aren't in the 'archive' dataset as deleted

### DIFF
--- a/cgi/oai2
+++ b/cgi/oai2
@@ -780,10 +780,8 @@ sub _list
 	$filters = [] unless defined $filters;
 
 	push @$filters, {
-		meta_fields => [qw( eprint_status )],
-		value => "archive deletion",
-		match => "EQ",
-		merge => "ANY",
+		meta_fields => [qw( datestamp )],
+		match => "SET",
 	};
 
 	# custom sets

--- a/perl_lib/EPrints/OpenArchives.pm
+++ b/perl_lib/EPrints/OpenArchives.pm
@@ -91,7 +91,7 @@ sub make_header
 
 	if( EPrints::Utils::is_set( $oai2 ) )
 	{
-		if( $eprint->get_dataset()->id() eq "deletion" )
+		if( $eprint->get_dataset()->id() ne "archive" )
 		{
 			$header->setAttribute( "status" , "deleted" );
 			return $header;
@@ -175,7 +175,7 @@ sub make_record
 	$record->appendChild( $session->make_indent( 4 ) );
 	$record->appendChild( $header );
 
-	if( $eprint->get_dataset()->id() eq "deletion" )
+	if( $eprint->get_dataset()->id() ne "archive" )
 	{
 		unless( EPrints::Utils::is_set( $oai2 ) )
 		{


### PR DESCRIPTION
If something is moved from archive to review, inbox, or dark_archive (if one is configured), the record is now reported as deleted in the OAI-PMH interface.
