### PR TITLE
Update xapian_warning.xml

### DIFF
--- a/lib/lang/en/phrases/xapian_warning.xml
+++ b/lib/lang/en/phrases/xapian_warning.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <!DOCTYPE phrases SYSTEM "entities.dtd">
 
 <epp:phrases xmlns="http://www.w3.org/1999/xhtml" xmlns:epp="http://eprints.org/ep3/phrase" xmlns:epc="http://eprints.org/ep3/control">


### PR DESCRIPTION
ISO-8859-1 encoding should generally be changed to UTF-8 because of other translations.