### PR TITLE
Update Subject.pm

### DIFF
--- a/perl_lib/EPrints/Plugin/Export/Subject.pm
+++ b/perl_lib/EPrints/Plugin/Export/Subject.pm
@@ -48,7 +48,10 @@ sub output_dataobj
 	push @parts, $dataobj->is_set( "depositable" ) && $dataobj->get_value( "depositable" ) eq "TRUE" ? "1" : "0";
 
 	# percent-encode ":" to "%3A"
-	@parts = map { s/:/%3A/g } @parts;
+	foreach my $i (0..$#parts)
+	{
+		$parts[$i] =~ s/:/%3A/g;	
+	}
 
 	return join(":", @parts)."\n";
 }


### PR DESCRIPTION
the substitution operator returns the number of matches, not the resulting text, so this results in @parts being full of empty strings.  Have replaced it with less clever code that works.