### PR TITLE
Escape spaces to underscores in file uploads

### DIFF
--- a/perl_lib/EPrints/System.pm
+++ b/perl_lib/EPrints/System.pm
@@ -541,7 +541,7 @@ sub sanitise
 		if !utf8::is_utf8( $filepath );
 
 	# control characters + Win32 restricted
-	$filepath =~ s![\x00-\x0f\x7f<>:"\\|?*]!_!g;
+	$filepath =~ s![\x00-\x0f\x7f\x20<>:"\\|?*]!_!g;
 
 	$filepath =~ s!\.+/!/!g; # /foo/../bar
 	$filepath =~ s!/\.+!/!g; # /foo/.bar/


### PR DESCRIPTION
Spaces do not look good in filenames, this just adds spaces to the list of characters being converted to underscores.  Issue #323