### PR TITLE
Remove duplicated phrase 'cgi/register:intro'.

### DIFF
--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -772,60 +772,6 @@ This field is required if no creators are listed.
 	<epp:phrase id="Plugin/Screen/Admin/Config/Edit/Config:inline_edit_title">Edit config file</epp:phrase>
 
 
-
-<!-- this is used for the minimal users who have their username locked to their
-     email address -->
-
-    <epp:phrase id="cgi/register:intro_minimal">
-<p>As a registered user you will be able to set up
-saved searches, which are sent when new items 
-are placed in the repository.</p>
-
-<p>Please complete the details on this page to register with <epc:phrase ref="archive_name" />.</p>
-
-<p>The registration process uses email to send you details of how to activate
-your account. You must then check your email and activate your password. Once
-activated you can start to use the registered features of the repository.</p>
-
-<p>If you have already registered but have forgotten your username or password,
-<a href="reset_password">click here</a> to set a new password.</p>
-    </epp:phrase>
-
-
-
-
-
-
-
-    <!-- registration introduction. -->
-    <epp:phrase id="cgi/register:intro">
-<p>You need to register in order to be able to deposit items in the 
-repository. </p>
-
-<p>As a registered user you will be able to manage your items, up to the point
-of submitting them for Editorial Review. If the review is successful your 
-item will be deposited in the repository, if it is unsuccessful it will be 
-returned to you with editorial comments.</p>
-
-<p>In addition to managing your items a registered user can set up
-alert options, so that email notifications are sent when new items 
-are placed in the repository.</p>
-
-<p>Please complete the details on this page to register with <epc:phrase ref="archive_name" />.</p>
-
-<p>The registration process uses email to send you details of how to activate
-your account. You must then check your email and activate your password. Once
-activated you can start to use the registered features of the repository.</p>
-
-<p>If you have already registered but have forgotten your username or password,
-<a href="reset_password">click here</a> to set a new password.</p>
-    </epp:phrase>
-
-
-
-
-
-
 <epp:phrase id="mail_bounce_reason">No reason was given.</epp:phrase>
 
 
@@ -2262,10 +2208,20 @@ Public CGI Scripts
     <epp:phrase id="cgi/register:intro">
 <p>In order to access some areas of the repository, you'll need a <em>user registration</em>. No charge is made for registering with us or using any of our services.</p>
 <p>This page lets you register with <epc:phrase ref="archive_name" />. This will allow you to save searches, receive alerts and deposit items.</p>
-<p>Your new password  will need to confirm your email address by using a code which will be mailed to you.</p>
+<p>A confirmation email will be sent to you. You need to activate your account using the link in the email.</p>
 <p>If you have already registered but have forgotten your username or password, <a href="reset_password">click here</a> to set a new password.</p>
 </epp:phrase>
-	<epp:phrase id="Plugin/Screen/Register:title">Create Account</epp:phrase>
+
+<!-- this is used for the minimal users who have their username locked to their email address -->
+    <epp:phrase id="cgi/register:intro_minimal">
+<p>As a registered user you will be able to set up saved searches, which are sent when new items are placed in the repository.</p>
+<p>Please complete the details on this page to register with <epc:phrase ref="archive_name" />.</p>
+<p>A confirmation email will be sent to you. You need to activate your account using the link in the email.</p>
+<p>If you have already registered but have forgotten your username or password,
+<a href="reset_password">click here</a> to set a new password.</p>
+    </epp:phrase>
+
+    <epp:phrase id="Plugin/Screen/Register:title">Create Account</epp:phrase>
     <epp:phrase id="cgi/register:action_submit">Register</epp:phrase>
     <epp:phrase id="cgi/register:title">Register</epp:phrase>
     <epp:phrase id="cgi/register:missing_field"><p>You have not filled in the &quot;<epc:pin name="fieldname"/>&quot; field.</p></epp:phrase>


### PR DESCRIPTION
Duplicated phrases were different.
Retained text of second phrase (as this would have overridden the first defined phrase) and corrected text.

Moved location of cgi/register:intro_minimal to be with other registration phrases and refined text.
