### PR TITLE
add Google reCAPTCHA to Copy Request form

### DIFF
--- a/lib/defaultcfg/cfg.d/plugins.pl
+++ b/lib/defaultcfg/cfg.d/plugins.pl
@@ -63,3 +63,11 @@ $c->{plugins}->{"Import::DOI"}->{params}->{pid} = "ourl_eprintsorg:eprintsorg";
 $c->{plugins}->{"Import::DOI"}->{params}->{doi_field} = "id_number";
 $c->{plugins}->{"Import::DOI"}->{params}->{use_prefix} = 1;
 
+# Google reCAPTCHA for "Request a Copy" form
+# See: https://www.google.com/recaptcha/
+
+#$c->{ plugins }->{ "Screen::Public::RequestCopy" }->{ params }->{ "reCAPTCHA" } = {
+#    'site-key' => 'xxxxxxxxyyyyyyyyaaaaaaaabbbbbbbbcccccccc',
+#    'secret'   => 'xxxxxxxxyyyyyyyyddddddddeeeeeeeeffffffff'
+#};
+


### PR DESCRIPTION
This is opened to **discuss peoples' opinions** on adding this (or similar) functionality. The code is in use on our public repository, but that doesn't mean it's up to scratch for general deployment.

Missing from the current branch:

* assurance that both required keys are present in the config hash

Possible enhancements:

* don't display the reCAPTCHA field if there's a valid user session (?)
* modularise the render/verify subs so reCAPTCHA can be used on other Screens, or so other services can be used