### PR TITLE
Update Id.pm

### DIFF
--- a/perl_lib/EPrints/MetaField/Id.pm
+++ b/perl_lib/EPrints/MetaField/Id.pm
@@ -45,6 +45,8 @@ sub value_from_sql_row
 {
 	my( $self, $session, $row ) = @_;
 
+	return undef unless defined $row->[0];
+
 	if( $session->{database}->{dbh}->{Driver}->{Name} eq "mysql" )
 	{
 		utf8::decode( $row->[0] );

--- a/perl_lib/EPrints/MetaField/Id.pm
+++ b/perl_lib/EPrints/MetaField/Id.pm
@@ -45,11 +45,9 @@ sub value_from_sql_row
 {
 	my( $self, $session, $row ) = @_;
 
-	return undef unless defined $row->[0];
-
 	if( $session->{database}->{dbh}->{Driver}->{Name} eq "mysql" )
 	{
-		utf8::decode( $row->[0] );
+		utf8::decode( $row->[0] ) if defined $row->[0];
 	}
 
 	return shift @$row;


### PR DESCRIPTION
Fixes #359 - suggested by Adam (http://www.eprints.org/tech.php/21050.html).

Is this issue being caused by Id field getting used for something that didn't used to be an Id?
e.g. eprintid, docid, userid... this is the primary key - and should be set.
If it's being used for an exact-string (e.g. so we can search on it), then it's valid that it's not set?

Or to put it another way: am I fixing the symptoms rather than the cause?
