### PR TITLE
WIP: XSlate templating

### DIFF
--- a/lib/citations/eprint/default.tx
+++ b/lib/citations/eprint/default.tx
@@ -1,0 +1,5 @@
+<span>
+	<: $item.render_value( 'creators_name' ) | mark_raw :> (<: $item.render_value( 'date' ) :>) <em><: $item.render_value( 'title' ) | magicstop :></em>
+
+	<: if $item.value( 'publication' ) { :> <: $item.render_value( 'publication' ) :><: if $item.value( 'volume' ) { :>, <: $item.render_value( 'volume' ) } :><: if $item.value( 'number' ) { :> (<: $item.render_value( 'number' ) :>)<: } :>.<: } :>
+</span>

--- a/lib/citations/eprint/summary_page.tx
+++ b/lib/citations/eprint/summary_page.tx
@@ -1,0 +1,42 @@
+<div>
+	: include 'eprint/default.tx';	
+
+	<ul>
+	: for documents( $item ) -> $doc {
+		: if $doc.is_public() {
+		<li><a href="<: $doc.url() :>"><img src="<: $doc.thumbnail_url() :>" /> <: $doc.render_value( 'content' ) :> <: human_filesize( doc_size( $doc ) ) :></a></li>
+		: }
+	: }
+	</ul>
+
+	<h2><: $repo.phrase( 'eprint_fieldname_abstract' ) :></h2>
+	<div><: $item.value( 'abstract' ) :></div>
+
+	<table style="margin-bottom: 1em; margin-top: 1em;" cellpadding="3">
+	: for $flags['summary_page_metadata'] -> $fieldname {
+		: if $item.value( $fieldname ) {
+		<tr>
+			<th align="right"><: $repo.phrase( 'eprint_fieldname_' ~ $fieldname ) :></th>
+			<td valign="top"><: $item.render_value( $fieldname ) | mark_raw :></td>
+		</tr>
+		: }
+	: }
+		<tr>
+			<th align="right">URI:</th>
+			<td valign="top"><a href="<: $item.uri() :>"><: $item.uri() :></a></td>
+		</tr>
+	</table>
+
+	:if $flags['preview'] != 1 {
+	<h2><: $repo.phrase( 'summary_page:actions' ) :></h2>
+	<table class="ep_summary_page_actions">	
+		: for $actions -> $action {
+		<tr>
+			<td><: $action['screen'].render_action_icon( $action ) | mark_raw :></td>
+			<td><: $repo.phrase( 'Plugin/' ~ replace( $action['screen_id'], '::', '/' ) ~ ':title' ) :> </td>
+		</tr>
+		: }
+	</table>
+	: }
+
+</div>

--- a/lib/templates/common/help.tx
+++ b/lib/templates/common/help.tx
@@ -1,0 +1,22 @@
+
+	<div class="ep_summary_box" id="ep_review_instructions">
+		<div class="ep_summary_box_title">
+			<div class="ep_no_js">
+				Help
+			</div>
+
+			<div class="ep_only_js" id="ep_review_instructions_colbar" style="display: none">
+				<a class="ep_box_collapse_link" href="#" onclick="EPJS_blur(event); EPJS_toggleSlideScroll('ep_review_instructions_content',true,'ep_review_instructions');EPJS_toggle('ep_review_instructions_colbar',true);EPJS_toggle('ep_review_instructions_bar',false);return false"><img alt="-" border="0" src="/style/images/minus.png" /> Help</a>
+			</div>
+
+			<div class="ep_only_js" id="ep_review_instructions_bar">
+				<a class="ep_box_collapse_link" href="#" onclick="EPJS_blur(event); EPJS_toggleSlideScroll('ep_review_instructions_content',false,'ep_review_instructions');EPJS_toggle('ep_review_instructions_colbar',false);EPJS_toggle('ep_review_instructions_bar',true);return false"><img alt="+" border="0" src="/style/images/help.gif" /> Help</a>
+			</div>
+		</div>
+
+		<div class="ep_summary_box_body" id="ep_review_instructions_content" style="display: none">
+			<div id="ep_review_instructions_content_inner">
+				<: $repo.html_phrase( $phrase_id ) | mark_raw :>
+			</div>
+		</div>
+	</div>

--- a/lib/templates/common/paginated_table.tx
+++ b/lib/templates/common/paginated_table.tx
@@ -1,0 +1,132 @@
+
+:# Querystring param whitelist for link building
+: my $whitelist = [ 'screen', $basename ~ '_page_size', $basename ~ '_order' ];
+
+: block table_header -> {
+
+:# Search results
+<div class="ep_search_results">
+	<table border="0" cellpadding="4" cellspacing="0" class="ep_columns">
+		<tr class="header_plain">
+		: my $new_sort_dir = $sort_dir == '-' ? '' : '-';
+		: for $columns -> $column {
+			<th class="ep_columns_title" style="padding:0px">
+			: if ( $column == $sort_col ) {
+				<table border="0" cellpadding="0" cellspacing="0" width="100%">
+					<tr>
+						<td>
+							<a href="<: link_self( $repo, $whitelist, $basename ~ '_order' => $new_sort_dir ~ $column ) :>" style="display:block;padding:4px"><: $repo.phrase( 'eprint_fieldname_' ~ $column ) :></a>
+						</td>
+
+						<td style="width:22px; text-align: right">
+							<a href="<: link_self( $repo, $whitelist, $basename ~ '_order' => $new_sort_dir ~ $column ) :>"><: if ( $sort_dir == '-' ) { :><img alt="Down" border="0" src="/style/images/sorting_down_arrow.gif" style="border:0px;padding:4px" /><: } else { :><img alt="Up" border="0" src="/style/images/sorting_up_arrow.gif" style="border:0px;padding:4px" /><: } :></a>
+						</td>
+					</tr>
+				</table>
+			: }
+			: else
+			: {
+				<table border="0" cellpadding="0" cellspacing="0" width="100%">
+					<tr>
+						<td>
+							<a href="<: link_self( $repo, $whitelist, $basename ~ '_order' => $new_sort_dir ~ $column ) :>" style="display:block;padding:4px"><: $repo.phrase( 'eprint_fieldname_' ~ $column ) :></a>
+						</td>
+					</tr>
+				</table>
+			: }
+			</th>
+		: }
+			<th class="ep_columns_title ep_columns_title_last" style="padding:0px" />
+		</tr>
+: }
+: block results -> {}
+
+: block table_footer -> {
+		:# Table modification (move left/right, delete)
+		<tr>
+		: for $columns -> $column {
+			<td class="ep_columns_alter">
+				<table border="0" cellpadding="0" cellspacing="0" width="100%">
+					<tr>
+					: if ( $~column.is_first ) {
+						<td align="left" width="14"><img alt="" src="/style/images/noicon.png" /></td>
+					: } else {
+						<td align="left" width="14">
+							<form accept-charset="utf-8" action="/cgi/users/home" enctype="multipart/form-data" method="post">
+								<input id="screen" name="screen" type="hidden" value="Items" /><input id="colid" name="colid" type="hidden" value="<: $~column :>" /><input alt="&lt;" name="_action_col_left" src="/style/images/left.png" title="Move Left" type="image" value="Move Left" />
+							</form>
+						</td>
+					: }
+
+						<td align="center" width="100%">
+							<form accept-charset="utf-8" action="/cgi/users/home" enctype="multipart/form-data" method="post">
+								<input id="screen" name="screen" type="hidden" value="Items" /><input id="colid" name="colid" type="hidden" value="<: $~column :>" /><input alt="X" name="_action_remove_col" onclick="if( window.event ) { window.event.cancelBubble = true; } return confirm( &quot;Really remove this column from the display?&quot;);" src="/style/images/delete.png" title="Remove Column" type="image" value="Remove Column" />
+							</form>
+						</td>
+
+					: if ( $~column.is_last ) {
+						<td align="right" width="14"><img alt="" src="/style/images/noicon.png" /></td>
+					: } else {
+						<td align="right" width="14">
+							<form accept-charset="utf-8" action="/cgi/users/home" enctype="multipart/form-data" method="post">
+								<input id="screen" name="screen" type="hidden" value="Items" /><input id="colid" name="colid" type="hidden" value="<: $~column :>" /><input alt="&gt;" name="_action_col_right" src="/style/images/right.png" title="Move Right" type="image" value="Move Right" />
+							</form>
+						</td>
+					: }
+					</tr>
+				</table>
+			</td>
+		: }
+			<td class="ep_columns_alter ep_columns_alter_last" />
+		</tr>
+	</table>
+</div>
+
+<div class="ep_search_controls_bottom">
+	<div>Displaying results <span class="ep_search_number"><: $offset + 1 :></span> to 
+	<span class="ep_search_number"><: ( ( $offset + $pagesize ) > $total ) ? $total : ( $offset + $pagesize ) :></span> of 
+	<span class="ep_search_number"><: $total :></span>. 
+
+	Show <a href="<: link_self( $repo, $whitelist, $basename ~ '_page_size' => 10 ) :>">10</a>, 
+	<a href="<: link_self( $repo, $whitelist, $basename ~ '_page_size' => 25 ) :>">25</a> or 
+	<a href="<: link_self( $repo, $whitelist, $basename ~ '_page_size' => 100 ) :>">100</a> or results per page. 
+
+	: if ( $pages > 1 ) {
+		<a href="<: link_self( $repo, $whitelist, $basename ~ '_page_size' => $total ) :>">Show All</a><br>
+
+
+		: if ( $current_page > 1 ) {
+			<span class="ep_search_control"><a href="<: link_self( $repo, $whitelist, $basename ~ '__offset' => ( $offset - $pagesize ) ) :>">Previous</a></span> |
+		: }
+
+		: for [1 .. $pages] -> $i {
+			<span class="ep_search_control">
+			: if ( $~i == ( $current_page - 1 ) ) {
+				<strong><: $current_page :></strong>
+			: } else {
+				<a href="<: link_self( $repo, $whitelist, $basename ~ '__offset' => ( $pagesize * ( $i - 1 ) ) ) :>"><: $i :></a>
+			: }
+			</span> |
+		: }
+
+		: if ( $current_page != $pages ) {
+			<span class="ep_search_control"><a href="<: link_self( $repo, $whitelist, $basename ~ '__offset' => ( $offset + $pagesize ) ) :>">Next</a></span>
+		: }
+	: }
+	</div>
+</div>
+
+: }
+
+
+<div class="ep_columns_add">
+	<form accept-charset="utf-8" action="/cgi/users/home" enctype="multipart/form-data" method="post">
+		<input id="screen" name="screen" type="hidden" value="Items" />
+		<select id="col" name="col" size="1">
+			: for $extra_cols.kv() -> $col {
+			<option value="<: $col.value :>"><: $col.key :></option>
+			: }
+		</select>
+		<input class="ep_form_action_button" name="_action_add_col" type="submit" value="Add Column" />
+	</form>
+</div>

--- a/lib/templates/default.tx
+++ b/lib/templates/default.tx
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<title><: $title_textonly ? $title_textonly : $title :> - <: $archive_name :></title>
+		<link rel="icon" href="<: $repo.config( 'rel_path' ) :>/favicon.ico" type="image/x-icon"/>
+		<link rel="shortcut icon" href="<: $repo.config( 'rel_path' ) :>/favicon.ico" type="image/x-icon"/>
+		<: $head | mark_raw :>
+	</head>
+
+	<body>
+		<: $pagetop :>
+		<div class="ep_tm_header ep_noprint">
+			<div class="ep_tm_site_logo">
+				<a href="<: $repo.config( 'frontpage' ) :>" title="<: $repo.phrase( 'archive_name' ) :>">
+					<img alt="<: $repo.phrase( 'archive_name' ) :>" src="<: $repo.config( 'rel_path' ) :><: $repo.config( 'site_logo' ) :>"/>
+				</a>
+			</div>
+			<ul class="ep_tm_menu">
+				<li>
+					<a href="<: $repo.config( 'http_url' ) :>">
+						<: $repo.phrase( 'template/navigation:home' ) :>
+					</a>
+				</li>
+				<li>
+					<a href="<: $repo.config( 'http_url' ) :>/information.html">
+						<: $repo.phrase( 'template/navigation:about' ) :>
+					</a>
+				</li>
+				<li>
+					<a href="<: $repo.config( 'http_url' ) :>/view/" class="ep_tm_menu_browse">
+						<: $repo.phrase( 'template/navigation:browse' ) :>
+					</a>
+					<ul id="ep_tm_menu_browse" style="display:none;">
+						<li>
+							<a href="<: $repo.config( 'http_url' ) :>/view/year/">
+								<: $repo.phrase( 'bin/generate_views:indextitleprefix' ) :>
+								<: $repo.phrase( 'viewname_eprint_year' ) :>
+							</a>
+						</li>
+						<li>
+							<a href="<: $repo.config( 'http_url' ) :>/view/subjects/">
+								<: $repo.phrase( 'bin/generate_views:indextitleprefix' ) :>
+								<: $repo.phrase( 'viewname_eprint_subjects' ) :>
+							</a>
+						</li>
+						<li>
+							<a href="<: $repo.config( 'http_url' ) :>/view/divisions/">
+								<: $repo.phrase( 'bin/generate_views:indextitleprefix' ) :>
+								<: $repo.phrase( 'viewname_eprint_divisions' ) :>
+							</a>
+						</li>
+						<li>
+							<a href="<: $repo.config( 'http_url' ) :>/view/creators/">
+								<: $repo.phrase( 'bin/generate_views:indextitleprefix' ) :>
+								<: $repo.phrase( 'viewname_eprint_creators' ) :>
+							</a>
+						</li>
+					</ul>
+				</li>
+			</ul>
+			<table class="ep_tm_searchbar">
+				<tr>
+					<td>
+						<: $login_status | mark_raw :>
+					</td>
+					<td style="white-space: nowrap">
+						<: $languages :>
+						<form method="get" accept-charset="utf-8" action="<: $repo.config( 'http_cgiurl' ) :>/search" style="display:inline">
+							<input class="ep_tm_searchbarbox" size="20" type="text" name="q"/>
+							<input class="ep_tm_searchbarbutton" value="<: $repo.phrase( 'lib/searchexpression:action_search' ) :>" type="submit" name="_action_search"/>
+							<input type="hidden" name="_action_search" value="Search"/>
+							<input type="hidden" name="_order" value="bytitle"/>
+							<input type="hidden" name="basic_srchtype" value="ALL"/>
+							<input type="hidden" name="_satisfyall" value="ALL"/>
+						</form>
+					</td>
+				</tr>
+			</table>
+		</div>
+		<div>
+			<div class="ep_tm_page_content">
+
+				<h1 class="ep_tm_pagetitle"><: $title | mark_raw :></h1>
+
+				<: $page | mark_raw :>
+			</div>
+		</div>
+
+		<div class="ep_tm_footer ep_noprint">
+			<div class="ep_tm_eprints_logo">
+				<a href="http://eprints.org/software/">
+					<img alt="EPrints Logo" src="<: $repo.config( 'rel_path' ) :>/images/eprintslogo.gif"/>
+				</a>
+			</div>
+			<: $repo.html_phrase( "template:about_eprints" ) | mark_raw :>
+		</div>
+	</body>
+</html>

--- a/lib/templates/plugins/screen/items.tx
+++ b/lib/templates/plugins/screen/items.tx
@@ -1,0 +1,73 @@
+: cascade common::paginated_table
+
+:# Querystring param whitelist for link building
+: my $whitelist = [ 'screen', $basename ~ '__offset', $basename ~ '_order' ];
+
+: before table_header -> {
+
+:# Introduction
+: if ( $repo.get_lang.has_phrase( 'intro' ) ) {
+<div class="ep_toolbox">
+	<div class="ep_toolbox_content">
+		<: $repo.html_phrase( 'intro' ) | mark_raw :>
+	</div>
+</div>
+: }
+
+:# Help
+<div style="text-align: left">
+: include 'common/help.tx' { phrase_id => 'Plugin/Screen/Items:help' };
+</div>
+
+<div class="ep_block">
+	<ul class="ep_action_list">
+	: for $tools -> $tool {
+		<li><: $tool['screen'].render_action_button( $tool ) | mark_raw :></li>
+	: }
+	</ul>
+</div>
+
+:# Import options
+<: $import_bar | mark_raw :>
+
+:# Dataset filters
+<div class="ep_items_filters">
+: for $filters.kv() -> $filter {
+	: if $filter.value {
+		<a href="<: link_self( $repo, $whitelist, ('set_show_' ~ $filter.key) => 0 ) :>"><img alt="Showing" src="/style/images/checkbox_tick.png" /> <: $repo.html_phrase( 'eprint_fieldopt_eprint_status_' ~ $filter.key ) :></a>
+	: }
+	: else
+	: {
+		<a href="<: link_self( $repo, $whitelist, ('set_show_' ~ $filter.key) => 1 ) :>"><img alt="Not showing" src="/style/images/checkbox_empty.png" /> <: $repo.html_phrase( 'eprint_fieldopt_eprint_status_' ~ $filter.key ) :></a> 
+	: }
+: }
+</div>
+: }
+
+: override results -> {
+	: if $has_eprints {
+		: for $eprints -> $eprint {
+		<tr class="<: $~eprint.cycle( 'row_b', '' ) :>">
+			: for $columns -> $column {
+				:# Need to add classes: ep_columns_cell_<: $dataset :>
+			<td class="ep_columns_cell ep_columns_cell_<: $eprint.value( 'eprint_status' ) :> <: if $~column.is_first { :> ep_columns_cell_first<: } :> ep_columns_cell_<: $column :>">
+				<: $eprint.render_value( $column ) :>
+			</td>
+			: }
+
+			<td align="left" class="ep_columns_cell ep_columns_cell_last">
+				<ul class="ep_action_list">
+			: for $actions[ $eprint.id() ] -> $action {
+					<li><: $action['screen'].render_action_icon( $action, hidden => $action[ 'hidden' ] ) | mark_raw :></li>
+			: }
+				</ul>
+			</td>
+		</tr>
+		: }
+	: } else {
+		<tr>
+			<td class="ep_columns_no_items" colspan="<: $columns.size() + 1 :>">No items</td>
+		</tr>
+	: }
+
+: }

--- a/perl_lib/EPrints/DataObj.pm
+++ b/perl_lib/EPrints/DataObj.pm
@@ -1135,6 +1135,29 @@ sub render_citation
 		$style = 'default';
 	}
 
+	my $repo = $self->{session};
+	my @plugins = $repo->get_plugins( type => 'Template', template_file => $self->{dataset}->id() . '/' . $style );
+
+	# If there is a matching template plugin, use it render the
+	# citation
+	if ( scalar @plugins )
+	{
+
+	    my $plugin = $plugins[0];
+
+	    # Maybe the plugin should do this basic template variable
+	    # setup?
+	    my $vars = \%params;
+	    $vars->{item} = $self;
+	    $vars->{ds} = $self->dataset();
+
+	    return $plugin->get_xml( $self->{dataset}->id() . '/' . $style, $vars );
+	}
+
+	# There is no suitable Template plugin available, use the old
+	# school citations (Perhaps these should be converted to a
+	# Template plugin too?)
+
 	my $citation = $self->{dataset}->citation( $style );
 
 	# no citation style available, not even "default"

--- a/perl_lib/EPrints/Plugin/Screen/Items.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Items.pm
@@ -127,6 +127,11 @@ sub get_filters
 		@f = ( inbox=>1, buffer=>1, archive=>1, deletion=>1 );
 	}
 
+	# @f is like ('archive', 1, 'buffer', 0, 'deletion', 0,
+	# 'inbox', 1), i.e., alternating values of keys and
+	# values. The code iterates through the keys and checks
+	# whether a querystring param has been set, if so it updates
+	# the user's preferences and exits.
 	foreach my $i (0..$#f)
 	{
 		next if $i % 2;
@@ -141,6 +146,8 @@ sub get_filters
 		}
 	}	
 
+	# Magic code to create an array of eprint states that the
+	# user's wishes to see
 	my @l = map { $f[$_] } grep { $_ % 2 == 0 && $f[$_+1] } 0..$#f;
 
 	return (
@@ -174,294 +181,83 @@ sub render
 {
 	my( $self ) = @_;
 
+	my $vars = {};
+
 	my $repo = $self->{session};
 	my $user = $repo->current_user;
-	my $chunk = $repo->make_doc_fragment;
 	my $imagesurl = $repo->current_url( path => "static", "style/images" );
 
-	### Get the items owned by the current user
+	# Get the items owned by the current user
 	my $list = $self->perform_search;
 
-	my $has_eprints = $user->owned_eprints_list()->count > 0;
+	my $has_eprints = $list->count > 0;
+	$vars->{has_eprints} = $has_eprints;
 
-	if( $repo->get_lang->has_phrase( $self->html_phrase_id( "intro" ), $repo ) )
-	{
-		my $intro_div_outer = $repo->make_element( "div", class => "ep_toolbox" );
-		my $intro_div = $repo->make_element( "div", class => "ep_toolbox_content" );
-		$intro_div->appendChild( $self->html_phrase( "intro" ) );
-		$intro_div_outer->appendChild( $intro_div );
-		$chunk->appendChild( $intro_div_outer );
-	}
+	# Dataset filters
+	my $pref = $self->{id} . '/eprint_status';
+	my %filters = @{$user->preference( $pref ) || [
+			    inbox => 1, buffer => 1, archive => 1, deletion => 1
+			    ]};
+	$vars->{filters} = \%filters;
 
-	{
-		my $phraseid = $has_eprints ? "Plugin/Screen/Items:help" : "Plugin/Screen/Items:help_no_items";
-		my %options;
-		if( $repo->get_lang->has_phrase( $phraseid, $repo ) )
-		{
-			$options{session} = $repo;
-			$options{id} = "ep_review_instructions";
-			$options{title} = $self->html_phrase( "help_title" );
-			$options{content} = $repo->html_phrase( $phraseid );
-			$options{collapsed} = 1;
-			$options{show_icon_url} = "$imagesurl/help.gif";
-			my $box = $repo->make_element( "div", style=>"text-align: left" );
-			$box->appendChild( EPrints::Box::render( %options ) );
-			$chunk->appendChild( $box );
-		}
-	}
-
-	$chunk->appendChild( $self->render_action_list_bar( "item_tools" ) );
-
-	my $import_screen = $repo->plugin( "Screen::Import" );
-	$chunk->appendChild( $import_screen->render_import_bar() ) if( defined $import_screen );
-
-	if( $has_eprints )
-	{
-		$chunk->appendChild( $self->render_items( $list ) );
-	}
-
-	return $chunk;
-}
-
-sub render_items
-{
-	my( $self, $list ) = @_;
-
-	my $session = $self->{session};
-	my $user = $session->current_user;
-	my $chunk = $session->make_doc_fragment;
-	my $imagesurl = $session->current_url( path => "static", "style/images" );
-	my $ds = $session->dataset( "eprint" );
-
-	my $pref = $self->{id}."/eprint_status";
-	my %filters = @{$session->current_user->preference( $pref ) || [
-		inbox=>1, buffer=>1, archive=>1, deletion=>1
-	]};
-
-	my $filter_div = $session->make_element( "div", class=>"ep_items_filters" );
-	foreach my $f ( qw/ inbox buffer archive deletion / )
-	{
-		my $url = URI->new( $session->current_url() );
-		my %q = $self->hidden_bits;
-		$q{"set_show_$f"} = !$filters{$f};
-		$url->query_form( %q );
-		my $link = $session->render_link( $url );
-		if( $filters{$f} )
-		{
-			$link->appendChild( $session->make_element(
-				"img",
-				src=> "$imagesurl/checkbox_tick.png",
-				alt=>"Showing" ) );
-		}
-		else
-		{
-			$link->appendChild( $session->make_element(
-				"img",
-				src=> "$imagesurl/checkbox_empty.png",
-				alt=>"Not showing" ) );
-		}
-		$link->appendChild( $session->make_text( " " ) );
-		$link->appendChild( $session->html_phrase( "eprint_fieldopt_eprint_status_$f" ) );
-		$filter_div->appendChild( $link );
-		$filter_div->appendChild( $session->make_text( ". " ) );
-	}
-
-	my $columns = $session->current_user->get_value( "items_fields" );
-	@$columns = grep { $ds->has_field( $_ ) } @$columns;
+	# Columns to display
+	my $columns = $user->get_value( "items_fields" );
+	my $ds = $repo->dataset( "eprint" );
+	@{$columns} = grep { $ds->has_field( $_ ) } @{$columns};
 	if( !EPrints::Utils::is_set( $columns ) )
 	{
-		$columns = [ "eprintid","type","eprint_status","lastmod" ];
-		$session->current_user->set_value( "items_fields", $columns );
-		$session->current_user->commit;
+		$columns = [ 'eprintid', 'type', 'eprint_status', 'lastmod' ];
+		$repo->current_user->set_value( 'items_fields', $columns );
+		$repo->current_user->commit;
 	}
+	$vars->{columns} = $columns;
 
+        # Extra cols that a user may choose to show
+	my $shown_cols;
+	%{$shown_cols} = map { $_ => 1 } @{$columns};
+	my @fields = $ds->fields();
+	my $extra_cols = {};
+	%{$extra_cols} = map { ( $shown_cols->{$_->name} != 1 ) ? ( $_->render_name => $_->name ) : () } @fields;
+	@fields = undef;
+	$vars->{extra_cols} = $extra_cols;
 
-	my $len = scalar @{$columns};
+	$vars->{basename} = '_buffer';
+	my $pagination_vars = EPrints::Paginate::Columns->paginate_list2( $repo, $vars->{basename}, $columns, $list );
+	$vars->{eprints} = $pagination_vars->{dataobjs};
+	delete $pagination_vars->{dataobjs};
 
-	my $final_row = undef;
-	if( $len > 1 )
-	{	
-		$final_row = $session->make_element( "tr" );
-		my $imagesurl = $session->config( "rel_path" )."/style/images";
-		for(my $i=0; $i<$len;++$i )
-		{
-			my $col = $columns->[$i];
-			# Column headings
-			my $td = $session->make_element( "td", class=>"ep_columns_alter" );
-			$final_row->appendChild( $td );
-	
-			my $acts_table = $session->make_element( "table", cellpadding=>0, cellspacing=>0, border=>0, width=>"100%" );
-			my $acts_row = $session->make_element( "tr" );
-			my $acts_td1 = $session->make_element( "td", align=>"left", width=>"14" );
-			my $acts_td2 = $session->make_element( "td", align=>"center", width=>"100%");
-			my $acts_td3 = $session->make_element( "td", align=>"right", width=>"14" );
-			$acts_table->appendChild( $acts_row );
-			$acts_row->appendChild( $acts_td1 );
-			$acts_row->appendChild( $acts_td2 );
-			$acts_row->appendChild( $acts_td3 );
-			$td->appendChild( $acts_table );
+	@{$vars}{keys %{$pagination_vars}} = values %{$pagination_vars};
 
-			if( $i!=0 )
-			{
-				my $form_l = $session->render_form( "post" );
-				$form_l->appendChild( 
-					$session->render_hidden_field( "screen", "Items" ) );
-				$form_l->appendChild( 
-					$session->render_hidden_field( "colid", $i ) );
-				$form_l->appendChild( $session->make_element( 
-					"input",
-					type=>"image",
-					value=>"Move Left",
-					title=>"Move Left",
-					src => "$imagesurl/left.png",
-					alt => "<",
-					name => "_action_col_left" ) );
-				$acts_td1->appendChild( $form_l );
-			}
-			else
-			{
-				$acts_td1->appendChild( $session->make_element("img",src=>"$imagesurl/noicon.png",alt=>"") );
-			}
+	# Action list
+	my $actions = {};
+	for my $eprint ( @{$vars->{eprints}} )
+	{
+	    $self->{processor}->{eprint} = $eprint;
+	    my @eprint_actions = $self->{processor}->list_items( 'eprint_item_actions', filter => 1 );
+	    delete $self->{processor}->{eprint};
 
-			my $msg = $self->phrase( "remove_column_confirm" );
-			my $form_rm = $session->render_form( "post" );
-			$form_rm->appendChild( 
-				$session->render_hidden_field( "screen", "Items" ) );
-			$form_rm->appendChild( 
-				$session->render_hidden_field( "colid", $i ) );
-			$form_rm->appendChild( $session->make_element( 
-				"input",
-				type=>"image",
-				value=>"Remove Column",
-				title=>"Remove Column",
-				src => "$imagesurl/delete.png",
-				alt => "X",
-				onclick => "if( window.event ) { window.event.cancelBubble = true; } return confirm( ".EPrints::Utils::js_string($msg).");",
-				name => "_action_remove_col" ) );
-			$acts_td2->appendChild( $form_rm );
+	    # Add the 'hidden' params so that the icons are generated
+	    # correctly
+	    for my $action ( @eprint_actions )
+	    {
+		$action->{hidden} = { eprintid => $eprint->id() };
+	    }
 
-			if( $i!=$len-1 )
-			{
-				my $form_r = $session->render_form( "post" );
-				$form_r->appendChild( 
-					$session->render_hidden_field( "screen", "Items" ) );
-				$form_r->appendChild( 
-					$session->render_hidden_field( "colid", $i ) );
-				$form_r->appendChild( $session->make_element( 
-					"input",
-					type=>"image",
-					value=>"Move Right",
-					title=>"Move Right",
-					src => "$imagesurl/right.png",
-					alt => ">",
-					name => "_action_col_right" ) );
-				$acts_td3->appendChild( $form_r );
-			}
-			else
-			{
-				$acts_td3->appendChild( $session->make_element("img",src=>"$imagesurl/noicon.png",alt=>"")  );
-			}
-		}
-		my $td = $session->make_element( "td", class=>"ep_columns_alter ep_columns_alter_last" );
-		$final_row->appendChild( $td );
+	    $actions->{ $eprint->id() } = \@eprint_actions;
 	}
+	$vars->{actions} = $actions;
 
-	# Paginate list
-	my %opts = (
-		params => {
-			screen => "Items",
-		},
-		columns => [@{$columns}, undef ],
-		above_results => $filter_div,
-		render_result => sub {
-			my( $session, $e, $info ) = @_;
+	# Item tools
+	my @tools = $self->{processor}->list_items( 'item_tools', filter => 1 );
+	$vars->{tools} = \@tools;
 
-			my $class = "row_".($info->{row}%2?"b":"a");
-			if( $e->is_locked )
-			{
-				$class .= " ep_columns_row_locked";
-				my $my_lock = ( $e->get_value( "edit_lock_user" ) == $session->current_user->get_id );
-				if( $my_lock )
-				{
-					$class .= " ep_columns_row_locked_mine";
-				}
-				else
-				{
-					$class .= " ep_columns_row_locked_other";
-				}
-			}
+	# Import bar - getting lazy, use existing DOM, output to
+	# string, and send the whole thing to the template!
+	my $import_screen = $repo->plugin( "Screen::Import" );
+	$vars->{import_bar} =  $import_screen->render_import_bar()->toString() if ( defined $import_screen );
 
-			my $tr = $session->make_element( "tr", class=>$class );
-
-			my $status = $e->get_value( "eprint_status" );
-
-			my $first = 1;
-			for( @$columns )
-			{
-				my $td = $session->make_element( "td", class=>"ep_columns_cell ep_columns_cell_$status".($first?" ep_columns_cell_first":"")." ep_columns_cell_$_"  );
-				$first = 0;
-				$tr->appendChild( $td );
-				$td->appendChild( $e->render_value( $_ ) );
-			}
-
-			$self->{processor}->{eprint} = $e;
-			$self->{processor}->{eprintid} = $e->get_id;
-			my $td = $session->make_element( "td", class=>"ep_columns_cell ep_columns_cell_last", align=>"left" );
-			$tr->appendChild( $td );
-			$td->appendChild( 
-				$self->render_action_list_icons( "eprint_item_actions", { 'eprintid' => $self->{processor}->{eprintid} } ) );
-			delete $self->{processor}->{eprint};
-
-			++$info->{row};
-
-			return $tr;
-		},
-		rows_after => $final_row,
-	);
-	$chunk->appendChild( EPrints::Paginate::Columns->paginate_list( $session, "_buffer", $list, %opts ) );
-
-
-	# Add form
-	my $div = $session->make_element( "div", class=>"ep_columns_add" );
-	my $form_add = $session->render_form( "post" );
-	$form_add->appendChild( $session->render_hidden_field( "screen", "Items" ) );
-
-	my $colcurr = {};
-	foreach( @$columns ) { $colcurr->{$_} = 1; }
-	my $fieldnames = {};
-        foreach my $field ( $ds->get_fields )
-        {
-                next unless $field->get_property( "show_in_fieldlist" );
-		next if $colcurr->{$field->get_name};
-		my $name = EPrints::Utils::tree_to_utf8( $field->render_name( $session ) );
-		my $parent = $field->get_property( "parent_name" );
-		if( defined $parent ) 
-		{
-			my $pfield = $ds->get_field( $parent );
-			$name = EPrints::Utils::tree_to_utf8( $pfield->render_name( $session )).": $name";
-		}
-		$fieldnames->{$field->get_name} = $name;
-        }
-
-	my @tags = sort { $fieldnames->{$a} cmp $fieldnames->{$b} } keys %$fieldnames;
-
-	$form_add->appendChild( $session->render_option_list( 
-		name => 'col',
-		height => 1,
-		multiple => 0,
-		'values' => \@tags,
-		labels => $fieldnames ) );
-		
-	$form_add->appendChild( 
-			$session->render_button(
-				class=>"ep_form_action_button",
-				name=>"_action_add_col", 
-				value => $self->phrase( "add" ) ) );
-	$div->appendChild( $form_add );
-	$chunk->appendChild( $div );
-	# End of Add form
-
-	return $chunk;
+	my $template = $repo->plugin( 'Template::Xslate' );
+	return $template->render( 'plugins/screen/items', $vars );
 }
 
 

--- a/perl_lib/EPrints/Plugin/Template/Xslate.pm
+++ b/perl_lib/EPrints/Plugin/Template/Xslate.pm
@@ -1,0 +1,311 @@
+package EPrints::Plugin::Template::Xslate;
+
+use strict;
+use warnings;
+
+#use base qw(EPrints::Plugin::Template);
+use base qw(EPrints::Plugin);
+
+our $DEFAULT_CACHE = 1;
+our $TEMPLATE_EXTENSION = '.tx';
+
+sub new
+{
+    my( $class, %params ) = @_;
+    
+    my $self = $class->SUPER::new( %params );
+
+    my $repo = $self->{repository};
+    my @template_dirs = $repo->template_dirs();
+    $self->{xslate_opts} = {
+	syntax => 'Kolon',
+	type => 'xml',
+	path => \@template_dirs,
+    };
+
+    $self->{disable} = !EPrints::Utils::require_if_exists( 'Text::Xslate' );
+
+    return $self;
+}
+
+sub matches
+{
+    my( $self, $test, $param ) = @_;
+    
+    if ( $test eq 'template_file' )
+    {
+	for my $path ( @{$self->{xslate_opts}->{path}} )
+	{
+	    return 1 if ( -e "${path}/${param}${TEMPLATE_EXTENSION}" );
+	}
+    }
+
+    return $self->SUPER::matches( $test, $param );
+}
+
+
+#
+# Returns text output from $template using $vars
+#
+sub render
+{
+    my( $self, $template, $vars ) = @_;
+
+    my $tx = $self->_tx();
+
+    $vars->{repo} = $self->{repository};
+
+    return $tx->render( "${template}${TEMPLATE_EXTENSION}", $vars );
+}
+
+
+#
+# Returns XML DOM output from $template using $vars
+#
+# This is pretty much a convenience while EPrints expects DOM in
+# certain places.
+#
+sub get_xml
+{
+    my( $self, $template, $vars ) = @_;
+
+    my $rendered = $self->render( $template, $vars );
+
+    my $repo = $self->{repository};
+    my $dom = $repo->make_doc_fragment();
+    eval 
+    {
+	$dom->appendChild( $repo->xml->parse_string( $rendered )->documentElement() );
+	1;
+    } or do
+    {
+	$repo->log( "[Error] Couldn't parse citation output as XML: $@" );
+    };
+
+    return $dom;
+}
+
+#
+# Return an EPrints::Page for the content specified by $map
+#
+# This code is taken pretty much verbatim from EPrints::XHTML::page()
+# - perhaps this code should go in EPrints::Plugin::Template.
+#
+# Requires the template specify the doctype
+#
+sub page
+{
+    my( $self, $map, %options ) = @_;
+
+    my $repo = $self->{repository};
+
+    # if mainonly=yes is in effect return the page content
+    if ( $repo->get_online &&
+	 $repo->param( "mainonly" ) &&
+	 $repo->param( "mainonly" ) eq "yes" )
+    {
+	if ( defined $map->{'utf-8.page'} )
+	{
+	    return EPrints::Page->new( $repo, $map->{'utf-8.page'}, add_doctype=>0 );
+	}
+	elsif ( defined $map->{page} )
+	{
+	    return EPrints::Page::DOM->new( $repo, $map->{page}, add_doctype=>0 );
+	}
+	else
+	{
+	    EPrints->abort( "Can't generate mainonly without page" );
+	}
+    }
+
+    # languages pin
+    my $plugin = $repo->plugin( "Screen::SetLang" );
+    $map->{languages} = $plugin->render_action_link if ( defined $plugin );
+    
+    $repo->run_trigger( EPrints::Const::EP_TRIGGER_DYNAMIC_TEMPLATE,
+			pins => $map,
+	);
+
+    # we've been called by an older script
+    if( !defined $map->{login_status} )
+    {
+	$map->{login_status} = EPrints::ScreenProcessor->new( session => $repo )->render_toolbar;
+    }
+
+    my $pagehooks = $repo->config( "pagehooks" );
+    $pagehooks = {} if !defined $pagehooks;
+    my $ph = $pagehooks->{$options{page_id}} if defined $options{page_id};
+    $ph = {} if !defined $ph;
+    if( defined $options{page_id} )
+    {
+	$ph->{bodyattr}->{id} = "page_".$options{page_id};
+    }
+
+    # only really useful for head & pagetop, but it might as
+    # well support the others
+    foreach ( keys %{$map} )
+    {
+	next if ( !defined $ph->{$_} );
+
+	my $pt = $repo->xml->create_document_fragment;
+	$pt->appendChild( $map->{$_} );
+	my $ptnew = $repo->clone_for_me( $ph->{$_}, 1 );
+	$pt->appendChild( $ptnew );
+	$map->{$_} = $pt;
+    }
+
+    if( !defined $options{template} )
+    {
+	$options{template} = 'default';
+    }
+
+    # Convert DOM bits to plain text
+    my $vars = {};
+    for my $part_key ( keys %{$map} )
+    { 
+	my $part = $map->{$part_key};
+	my $new_key = $part_key;
+	$new_key =~ s/utf-8\.//;
+	$new_key =~ s/\./_/;
+	if ( ref( $part ) =~ m/^XML::LibXML/ )
+	{
+	    $vars->{$new_key} = $repo->xhtml->to_xhtml( $part );
+	}
+	else
+	{
+	    $vars->{$new_key} = $part;
+	}
+    }
+
+    my $rendered = $self->render( $options{template}, $vars );
+
+    my $opts = { add_doctype => 0 };
+
+    return EPrints::Page->new( $repo, $rendered, %{$opts} );
+}
+
+
+#
+# Returns a Text::Xslate object
+#
+sub _tx
+{
+    my( $self ) = @_;
+
+    $self->{tx} = Text::Xslate->new( 
+        module => [
+	    'Text::Xslate::Bridge::Star',
+	    'EPrints::Template::Xslate::Functions'
+	],
+	%{$self->{xslate_opts}}
+	) if ( !defined $self->{tx} );
+
+    return $self->{tx};
+}
+
+1;
+
+#
+# Extension template functions - incomplete mirror of
+# EPrints::Script::Compiled
+#
+package EPrints::Template::Xslate::Functions;
+
+use parent qw(Text::Xslate::Bridge);
+
+use Carp qw(carp);
+use URI::QueryParam;
+
+sub documents
+{
+    my ( $eprint ) = @_;
+
+    my @result = $eprint->get_all_documents();
+
+    return \@result;
+
+}
+
+sub doc_size
+{
+    my( $doc ) = @_;
+
+    if ( !defined $doc || ref($doc) ne 'EPrints::DataObj::Document' )
+    {
+	carp( 'Can only call doc_size() on document objects not ' . ref( $doc ) );
+    }
+
+    if ( !$doc->is_set( 'main' ) )
+    {
+	return 0;
+    }
+
+    my %files = $doc->files;
+
+    return $files{$doc->get_main} || 0;
+}
+
+sub human_filesize
+{
+    my( $bytes ) = @_;
+
+    return EPrints::Utils::human_filesize( $bytes || 0 );
+}
+
+sub magicstop
+{
+    my ( $str ) = @_;
+    $str =~ s/([^.])$/$1\./;
+    return $str;
+}
+
+#
+# Returns a URL to the current resource. Any querystring params in
+# $whitelist that are already set are preserved except where overriden
+# by values in %overrides.
+#
+sub link_self
+{
+    my ( $repo, $whitelist, %overrides ) = @_;
+
+    my $url = URI->new( $repo->get_full_url() );
+
+    my $params = $url->query_form_hash();
+
+    # Remove params not in the whitelist
+    for my $param ( keys( %{$params} ) )
+    {
+	if ( !grep( /^$param$/, @{$whitelist} ) )
+	{
+	    delete( $params->{$param} );
+	}
+    }
+
+    # Apply overrides
+    for my $key ( keys %overrides )
+    { 
+	$params->{$key} = $overrides{$key};
+    }
+    $url->query_form_hash( $params );
+
+    return $url->as_string();
+}
+
+my %functions = (
+    documents => \&documents,
+    doc_size => \&doc_size,
+    human_filesize => \&human_filesize,
+    magicstop => \&magicstop,
+    link_self => \&link_self,
+    );
+
+__PACKAGE__->bridge(
+#    nil    => \%nil_methods,
+#    scalar => \%scalar_methods,
+#    array  => \%array_methods,
+#    hash   => \%hash_methods,
+
+    function => \%functions,
+    );
+
+1;

--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -4503,7 +4503,12 @@ sub build_page
 sub prepare_page
 {
 	my( $self, $map, %options ) = @_;
-	$self->{page} = $self->xhtml->page( $map, %options );
+	my @plugins = $self->get_plugins( type => 'Template' );
+	if ( !scalar @plugins )
+	{
+	    $self->{page} = $self->xhtml->page( $map, %options );
+	}
+	$self->{page} = $plugins[0]->page( $map, %options );
 }
 
 

--- a/perl_lib/EPrints/ScreenProcessor.pm
+++ b/perl_lib/EPrints/ScreenProcessor.pm
@@ -378,19 +378,38 @@ sub process
 	my $links = $self->screen->render_links;
 	my $title = $self->screen->render_title;
 
-	my $page = $self->{session}->make_doc_fragment;
-
-	foreach my $chunk ( @{$self->{before_messages}} )
+	my $page;
+	if ( ref( $content ) =~ m/^XML::LibXML/ )
 	{
-		$page->appendChild( $chunk );
-	}
-	$page->appendChild( $self->render_messages );
-	foreach my $chunk ( @{$self->{after_messages}} )
-	{
-		$page->appendChild( $chunk );
-	}
+	    $page = $self->{session}->make_doc_fragment;
 
-	$page->appendChild( $content );
+	    foreach my $chunk ( @{$self->{before_messages}} )
+	    {
+		$page->appendChild( $chunk );
+	    }
+	    $page->appendChild( $self->render_messages );
+	    foreach my $chunk ( @{$self->{after_messages}} )
+	    {
+		$page->appendChild( $chunk );
+	    }
+
+	    $page->appendChild( $content );
+	}
+	else
+	{
+	    # Assume $content is text
+
+	    foreach my $chunk ( @{$self->{before_messages}} )
+	    {
+		$page .= $self->{session}->xhtml->to_xhtml( $chunk );
+	    }
+	    $page .= $self->{session}->xhtml->to_xhtml( $self->render_messages );
+	    foreach my $chunk ( @{$self->{after_messages}} )
+	    {
+		$page .= $self->{session}->xhtml->to_xhtml( $chunk );
+	    }
+	    $page .= $content;
+	}
 
 	$self->{session}->prepare_page(  
 		{


### PR DESCRIPTION
This is a proof-of-concept for unifying EPrints UI code generation in a templating system, using [Text::Xslate](http://search.cpan.org/~syohex/Text-Xslate-3.3.7/). It works for citations, plugins and templates. There's some discussion of MVC and templating going on in https://github.com/eprints/eprints/issues/301 so I thought I would (finally!) make a PR of this in case it helped the discussion 

My approach was to make the minimal changes required to support a template system and to ensure that it could work alongside existing templating, so that migration of all of core code isn't required to adopt the new templating.

I've included eprints citations, a default template and a version of the Manage Eprints page to demonstrate how it works in practice.
