### PR TITLE
generated sitemap-sc.xml doesn't conform to schema

### DIFF
--- a/lib/defaultcfg/cfg.d/misc.pl
+++ b/lib/defaultcfg/cfg.d/misc.pl
@@ -92,3 +92,20 @@ $c->{cache_max} = 100;
 #        return EP_TRIGGER_OK;
 #});
 
+$c->add_trigger( EP_TRIGGER_LOCAL_SITEMAP_URLS, sub {
+    my( %args ) = @_;
+
+    my( $repository, $urlset ) = @args{qw( repository urlset )};
+
+    # <urlset/> must contain at least one <url/>
+    if( !$urlset->exists( './url/loc' ) )
+    {
+	# if none, add a pointer to the homepage
+	$urlset->appendChild( EPrints::Utils::make_sitemap_url( $repository, {
+	    loc => $repository->config( "frontpage" )
+	} ) );
+    }
+
+    return EP_TRIGGER_OK;
+}, priority => -10); # run after other handlers
+

--- a/perl_lib/EPrints/Apache/SiteMap.pm
+++ b/perl_lib/EPrints/Apache/SiteMap.pm
@@ -115,11 +115,11 @@ sub _new_urlset
 	);
 	_insert_semantic_web_extensions( $repository, $xml, $urlset );
 
-	# <urlset/> must include at least one <url/>
-	my $url = $xml->create_element( "url" );
-	my $urlloc = $xml->create_data_element( "loc", $repository->get_conf( "frontpage" ) );
-	$url->appendChild( $urlloc );
-	$urlset->appendChild( $url );
+	# <urlset/> must include at least one <url/>, so include a reference
+	# to the front page
+	$urlset->appendChild( EPrints::Utils::make_sitemap_url( $repository, {
+		loc => $repository->config( "frontpage" ),
+	} ) );
 
 	$document->appendChild( $urlset );
 

--- a/perl_lib/EPrints/Apache/SiteMap.pm
+++ b/perl_lib/EPrints/Apache/SiteMap.pm
@@ -114,13 +114,6 @@ sub _new_urlset
 			"xsi:schemaLocation" => "http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd",
 	);
 	_insert_semantic_web_extensions( $repository, $xml, $urlset );
-
-	# <urlset/> must include at least one <url/>, so include a reference
-	# to the front page
-	$urlset->appendChild( EPrints::Utils::make_sitemap_url( $repository, {
-		loc => $repository->config( "frontpage" ),
-	} ) );
-
 	$document->appendChild( $urlset );
 
 	return $document;

--- a/perl_lib/EPrints/Apache/SiteMap.pm
+++ b/perl_lib/EPrints/Apache/SiteMap.pm
@@ -109,9 +109,18 @@ sub _new_urlset
 	my $document = $xml->make_document();
 	my $urlset = $xml->create_element(
 			"urlset",
-			"xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9"
+			"xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9",
+			"xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
+			"xsi:schemaLocation" => "http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd",
 	);
 	_insert_semantic_web_extensions( $repository, $xml, $urlset );
+
+	# <urlset/> must include at least one <url/>
+	my $url = $xml->create_element( "url" );
+	my $urlloc = $xml->create_data_element( "loc", $repository->get_conf( "frontpage" ) );
+	$url->appendChild( $urlloc );
+	$urlset->appendChild( $url );
+
 	$document->appendChild( $urlset );
 
 	return $document;


### PR DESCRIPTION
According to the [sitemaps.org schema](http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd) a `<urlset/>` element must contain at least one `<url/>` element, but the _sitemap-sc.xml_ generated by the EPrints::Apache::SiteMap handler doesn't conform. This was reported to us by Google webmaster tools.

This patch updates the method that creates new `<urlset/>` elements, which is called when creating _sitemap-sc.xml_ and/or when no static _sitemap.xml_ file exists. I think that's the right place to do it.