### PR TITLE
Video thumbnails - wrong mime type

### DIFF
--- a/perl_lib/EPrints/Plugin/Convert/Thumbnails.pm
+++ b/perl_lib/EPrints/Plugin/Convert/Thumbnails.pm
@@ -768,7 +768,7 @@ sub export_cell
 
 	$offset = _seconds_to_marker( $offset );
 
-	$self->{_mime_type} = "image/jpg";
+	$self->{_mime_type} = "image/jpeg";
 
 	# extract the frame in MJPEG format
 	my $fn = $size . '.jpg';


### PR DESCRIPTION
image/jpg isn't a valid mime type. Should be image/jpeg.
