### PR TITLE
Fix warning in CGI::param (#1)

### DIFF
--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -565,7 +565,7 @@ sub param
 
         if( defined $name )
         {
-                @result = $self->{query}->param( $name );
+                @result = $self->{query}->multi_param( $name );
         }
         else
         {


### PR DESCRIPTION
The Apache2 error.log was flooded with warnings like this one:

CGI::param called in list context from package
 EPrints::Repository line 397, this can lead to vulnerabilities.
 See the warning in "Fetching the value or values of a
 single named parameter" at /usr/share/perl5/CGI.pm line 436.

As the code expects an array, using multi_param() instead of param()
seems to be adequate.

Signed-off-by: Stefan Weil <sw@weilnetz.de>