### PR TITLE
Add LSB tags to epindexer init.d script

### DIFF
--- a/bin/epindexer.in
+++ b/bin/epindexer.in
@@ -1,5 +1,15 @@
 #!@PERL_PATH@ -T -w
 
+### BEGIN INIT INFO
+# Provides:          epindexer
+# Required-Start:    $local_fs $remote_fs $network $syslog $named
+# Required-Stop:     $local_fs $remote_fs $network $syslog $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: EPrints indexer
+# Description:       Start the EPrints indexer daemon as the correct user.
+### END INIT INFO
+
 my $user = "@INSTALL_USER@";
 my $group = "@INSTALL_GROUP@";
 my $prefix = "@PREFIX@";
@@ -116,7 +126,7 @@ if( $opt eq 'stop' )
 delete $ENV{'PATH'};
 my $rv = system( @indexer_cmd );
 $rv = $rv >> 8;
-if( $opt eq 'start' || $opt eq 'stop' ) 
+if( $opt eq 'start' || $opt eq 'stop' )
 {
 	if( $rv == 0 )
 	{


### PR DESCRIPTION
Those tags are used by insserv (see man page) when running this command:

update-rc.d epindexer defaults

Signed-off-by: Stefan Weil <sw@weilnetz.de>