### PR TITLE
perl_lib: Fix typos in comments and strings

### DIFF
--- a/perl_lib/EPrints/Apache/CRUD.pm
+++ b/perl_lib/EPrints/Apache/CRUD.pm
@@ -168,7 +168,7 @@ Web browsers only allow GET and POST requests. To perform other requests use the
 
 =for MediaWiki {{Available|since=3.3.9}}
 
-If you have the I<upsert> privilege objects will be created on demand, otherwise attempting to PUT to a non-existant object will result in an error.
+If you have the I<upsert> privilege objects will be created on demand, otherwise attempting to PUT to a non-existent object will result in an error.
 
 =head1 METHODS
 

--- a/perl_lib/EPrints/DataObj/SavedSearch.pm
+++ b/perl_lib/EPrints/DataObj/SavedSearch.pm
@@ -291,7 +291,7 @@ sub send_out_alert
 	{
 		# Get today's date
 		my( $year, $month, $day ) = EPrints::Time::get_date_array( time );
-		# Substract a month		
+		# Subtract a month
 		$month--;
 
 		# Check for year "wrap"

--- a/perl_lib/EPrints/DataObj/Subject.pm
+++ b/perl_lib/EPrints/DataObj/Subject.pm
@@ -761,7 +761,7 @@ sub _get_subjects2
 }
 
 # cjg CACHE this per, er, session?
-# commiting a subject should erase the cache
+# committing a subject should erase the cache
 
 ######################################################################
 =pod
@@ -875,7 +875,7 @@ sub posted_eprints
 =item $count = $subject->count_eprints( $dataset )
 
 Return the number of eprints in the dataset which are in this subject
-or one of its decendants. Search all fields of type subject.
+or one of its descendants. Search all fields of type subject.
 
 =cut
 ######################################################################

--- a/perl_lib/EPrints/DataObj/User.pm
+++ b/perl_lib/EPrints/DataObj/User.pm
@@ -81,7 +81,7 @@ The email address of this user. Unique within the repository.
 
 =item lang (namedset) 
 
-The ID of the prefered language of this user. Only really used in multilingual
+The ID of the preferred language of this user. Only really used in multilingual
 repositories.
 
 =item editperms (search, multiple)

--- a/perl_lib/EPrints/DataSet.pm
+++ b/perl_lib/EPrints/DataSet.pm
@@ -1418,7 +1418,7 @@ Satify all conditions specified. 0 means satisfy any of the conditions specified
 
 =item "staff"=>1
 
-Do search as an adminstrator means you get everything back
+Do search as an administrator means you get everything back
 
 =item "custom_order" => "field1/-field2/field3"
 

--- a/perl_lib/EPrints/Database.pm
+++ b/perl_lib/EPrints/Database.pm
@@ -475,7 +475,7 @@ sub create_dataset_tables
 		$rv &&= $self->create_table( $main_table, 1, @main_fields );
 	}
 
-	# Create the auxillary tables
+	# Create the auxiliary tables
 	foreach my $field (@aux_fields)
 	{
 		my $table = $dataset->get_sql_sub_table_name( $field );
@@ -2316,7 +2316,7 @@ sub get_index_ids
 =item $ids = $db->search( $keyfield, $tables, $conditions, [$main_table_alias] )
 
 Return a reference to an array of ids - the results of the search
-specified by $conditions accross the tables specified in the $tables
+specified by $conditions across the tables specified in the $tables
 hash where keys are tables aliases and values are table names. 
 
 If no table alias is passed then M is assumed. 
@@ -2890,7 +2890,7 @@ sub _get
 		{
 			my( $id, $pos ) = splice(@values,0,2);
 			my $n = $lookup{ $id };
-			next unless defined $n; # junk data in auxillary tables?
+			next unless defined $n; # junk data in auxiliary tables?
 			$data[$n]->{$fn}->[$pos] = 
 				$multifield->value_from_sql_row( $self->{session}, \@values );
 		}
@@ -3376,7 +3376,7 @@ sub add_field
 	return $rc;
 }
 
-# Split a sql type definition into its constituant columns
+# Split a sql type definition into its constituent columns
 sub _split_sql_type
 {
 	my( $sql ) = @_;
@@ -4418,7 +4418,7 @@ sub get_driver_name
 
 =item @events = $db->dequeue_events( $n )
 
-Attempt to dequeue upto $n events. May return between 0 and $n events depending on parallel processes and how many events are remaining on the queue.
+Attempt to dequeue up to $n events. May return between 0 and $n events depending on parallel processes and how many events are remaining on the queue.
 
 =cut
 

--- a/perl_lib/EPrints/Index/Daemon/MSWin32.pm
+++ b/perl_lib/EPrints/Index/Daemon/MSWin32.pm
@@ -165,7 +165,7 @@ sub stop_worker
 	if( $self->is_worker_running )
 	{
 		# terminate stops the indexer dead
-		$self->log( 1, "** Worker failed to respond to INTERUPT, terminating" );
+		$self->log( 1, "** Worker failed to respond to INTERRUPT, terminating" );
 		$self->{worker}->Kill( 0 );
 	}
 

--- a/perl_lib/EPrints/Index/Tokenizer.pm
+++ b/perl_lib/EPrints/Index/Tokenizer.pm
@@ -233,7 +233,7 @@ $EPrints::Index::FREETEXT_ALWAYS_WORDS = {
 		"ok" => 1 
 };
 
-# Chars which seperate words. Pretty much anything except
+# Chars which separate words. Pretty much anything except
 # A-Z a-z 0-9 and single quote '
 
 # If you want to add other seperator characters then they

--- a/perl_lib/EPrints/Language.pm
+++ b/perl_lib/EPrints/Language.pm
@@ -295,7 +295,7 @@ sub phrase
 	{
 		if( !$used->{$_} )
 		{
-			# Should log this, but somtimes it's supposed to happen!
+			# Should log this, but sometimes it's supposed to happen!
 			# $session->get_repository->log( "Unused parameter \"$_\" passed to phrase \"$phraseid\"" );
 			EPrints::XML::dispose( $inserts->{$_} );
 		}

--- a/perl_lib/EPrints/Latex.pm
+++ b/perl_lib/EPrints/Latex.pm
@@ -123,7 +123,7 @@ sub render_string
 			{
 				my $param = $buffer;
 
-				# strip $ from begining and end.
+				# strip $ from beginning and end.
 				$param =~ s/^\$(.*)\$$/$1/;
 
 				# Mimetex can't handle whitespace. Change it to ~'s.
@@ -139,7 +139,7 @@ sub render_string
 				# URL Encode non a-z 0-9 chars.
 				$param =~ s/[^a-z0-9]/sprintf('%%%02X',ord($&))/ieg;
 	
-				# strip $ from begining and end.
+				# strip $ from beginning and end.
 				$param =~ s/^\$(.*)\$$/$1/; 
 	
 				$url = $session->config( 

--- a/perl_lib/EPrints/MetaField/Name.pm
+++ b/perl_lib/EPrints/MetaField/Name.pm
@@ -290,7 +290,7 @@ sub get_search_conditions
 		$noskip = 2;
 		if( length $gpart == 1 )
 		{
-			# inital
+			# initial
 			foreach my $l ( @{$list} )
 			{
 				$l .= '['.$gpart.'%';

--- a/perl_lib/EPrints/MetaField/Set.pm
+++ b/perl_lib/EPrints/MetaField/Set.pm
@@ -144,7 +144,7 @@ sub render_input_field_actual
 	$default = [ $value ] unless( $self->get_property( "multiple" ) );
 	$default = [] if( !defined $value );
 
-	# called as a seperate function because subject does this
+	# called as a separate function because subject does this
 	# bit differently, and overrides render_set_input.
 	return $self->render_set_input( $session, $default, $required, $obj, $basename );
 }

--- a/perl_lib/EPrints/MetaField/Storable.pm
+++ b/perl_lib/EPrints/MetaField/Storable.pm
@@ -15,7 +15,7 @@ B<EPrints::MetaField::Storable> - serialise/unserialise Perl structures
 
 =head1 DESCRIPTION
 
-This field supports arbitrary Perl data structures by serialising them using L<Storable>, upto the length of L<EPrints::MetaField::Longtext>.
+This field supports arbitrary Perl data structures by serialising them using L<Storable>, up to the length of L<EPrints::MetaField::Longtext>.
 
 When serialised into XML the values are further encoded in Base64 to avoid any problems with invalid XML character data being emitted by Storable.
 

--- a/perl_lib/EPrints/MetaField/Time.pm
+++ b/perl_lib/EPrints/MetaField/Time.pm
@@ -15,7 +15,7 @@ B<EPrints::MetaField::Time> - no description
 
 =head1 DESCRIPTION
 
-Can store a time value upto seconds granularity. The time must be in UTC because this field can not store the time zone part.
+Can store a time value up to seconds granularity. The time must be in UTC because this field can not store the time zone part.
 
 The value is set and returned as a string formatted as:
 

--- a/perl_lib/EPrints/Plugin/Convert/IndexCodes.pm
+++ b/perl_lib/EPrints/Plugin/Convert/IndexCodes.pm
@@ -48,7 +48,7 @@ sub export
 	EPrints::abort( "Can't find text conversion plugin" ) unless exists($types{$type});
 	my $plugin = $types{$type}->{"plugin"};
 
-	# Extract the text and read it all into $text (upto 4MB)
+	# Extract the text and read it all into $text (up to 4MB)
 	my @files = $plugin->export( $dir, $doc, "text/plain" );
 
 	my $text = "";

--- a/perl_lib/EPrints/Plugin/Export/XMLFiles.pm
+++ b/perl_lib/EPrints/Plugin/Export/XMLFiles.pm
@@ -18,7 +18,7 @@ sub new
 
 	my $self = $class->SUPER::new( %opts );
 
-	$self->{name} = "EP3 XML with Files Embeded";
+	$self->{name} = "EP3 XML with Files Embedded";
 	$self->{accept} = [ 'list/eprint', 'dataobj/eprint' ];
 
 	# this module outputs the files of an eprint with

--- a/perl_lib/EPrints/Plugin/Screen/EPrint/Deposit.pm
+++ b/perl_lib/EPrints/Plugin/Screen/EPrint/Deposit.pm
@@ -52,7 +52,7 @@ sub from
 			return;
 		}
 
-		# not checking that this succeded. Maybe we should.
+		# not checking that this succeeded. Maybe we should.
 		$self->{processor}->{screenid} = "EPrint::Edit";
 		$self->workflow->set_stage( $jump_to );
 		return;

--- a/perl_lib/EPrints/Plugin/Screen/EPrint/Edit.pm
+++ b/perl_lib/EPrints/Plugin/Screen/EPrint/Edit.pm
@@ -103,7 +103,7 @@ sub from
 
 		$self->workflow->set_stage( $jump_to );
 
-		# not checking that this succeded. Maybe we should.
+		# not checking that this succeeded. Maybe we should.
 		return;
 	}
 

--- a/perl_lib/EPrints/Plugin/Screen/Register.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Register.pm
@@ -156,7 +156,7 @@ sub action_confirm
 	# other value when they set theirs.
 
 	# This script hacks the SQL directly, as normally "secret" fields are not
-	# accessable to eprints. 
+	# accessible to eprints.
 	
 	if( $user->is_set( "newemail" ) )
 	{

--- a/perl_lib/EPrints/Plugin/Screen/Staff/IssueSearch.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Staff/IssueSearch.pm
@@ -121,7 +121,7 @@ sub render_result_row
 			n => [$n,"INTEGER"] );
 }
 
-# Supress the anyall field - not interesting.
+# Suppress the anyall field - not interesting.
 sub render_anyall_field
 {
 	my( $self ) = @_;

--- a/perl_lib/EPrints/Plugin/Screen/Workflow/Edit.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Workflow/Edit.pm
@@ -77,7 +77,7 @@ sub from
 
 		$self->workflow->set_stage( $jump_to );
 
-		# not checking that this succeded. Maybe we should.
+		# not checking that this succeeded. Maybe we should.
 		return;
 	}
 

--- a/perl_lib/EPrints/PluginFactory.pm
+++ b/perl_lib/EPrints/PluginFactory.pm
@@ -269,7 +269,7 @@ sub _load_plugin
 	no strict "refs";
 	my $disvar = $class.'::DISABLE';
 	my $disable = ${$disvar};
-	$disable = ${$disvar}; # supress "only once" warning
+	$disable = ${$disvar}; # suppress "only once" warning
 	#my %defaults = $class->defaults();
 	use strict "refs";
 	return if( $disable );

--- a/perl_lib/EPrints/Repository.pm
+++ b/perl_lib/EPrints/Repository.pm
@@ -2298,7 +2298,7 @@ Given an repository object and a Apache (mod_perl) request object, this
 method decides what language the session should be.
 
 First it looks at the HTTP cookie "eprints_lang", failing that it
-looks at the prefered language of the request from the HTTP header,
+looks at the preferred language of the request from the HTTP header,
 failing that it looks at the default language for the repository.
 
 The language ID it returns is the highest on the list that the given
@@ -2356,7 +2356,7 @@ sub get_session_language
 	}
 
 	print STDERR <<END;
-Something odd happend in the language selection code... 
+Something odd happened in the language selection code...
 Did you make a default language which is not in the list of languages?
 END
 	return undef;
@@ -2527,7 +2527,7 @@ sub get_langid
 
 =item $value = EPrints::Repository::best_language( $repository, $lang, %values )
 
-$repository is the current repository. $lang is the prefered language.
+$repository is the current repository. $lang is the preferred language.
 
 %values contains keys which are language ids, and values which is
 text or phrases in those languages, all translations of the same 
@@ -2771,7 +2771,7 @@ sub get_full_url
 
 =item $noise_level = $repository->get_noise
 
-Return the noise level for the current session. See the explaination
+Return the noise level for the current session. See the explanation
 under EPrints::Repository->new()
 
 =end InternalDoc
@@ -3824,7 +3824,7 @@ sub render_form
 Return as XHTML DOM a nested set of <ul> and <li> tags describing
 part of a subject tree.
 
-$subject_list is a array ref of subject ids to render.
+$subject_list is an array ref of subject ids to render.
 
 $baseid is top top level node to render the tree from. If only a single
 subject is in subject_list, all subjects up to $baseid will still be
@@ -4296,7 +4296,7 @@ sub render_message
 # $xhtml = $repository->render_tabs( %params )
 #
 # Render javascript tabs to switch between views. The views must be
-# rendered seperately. 
+# rendered separately.
 
 # %params contains the following options:
 # id_prefix: the prefix of the id attributes.

--- a/perl_lib/EPrints/Search.pm
+++ b/perl_lib/EPrints/Search.pm
@@ -179,7 +179,7 @@ Filter definitions take the form of:
 like normal search fields except that they do not appear in the web form
 so force certain search parameters on the user.
 
-An optional parameter of describe=>0 can be set to supress the filter
+An optional parameter of describe=>0 can be set to suppress the filter
 being mentioned in the description of the search.
 
 =back
@@ -548,7 +548,7 @@ sub serialise
 	foreach( @parts )
 	{
 		# clone the string, so we can escape it without screwing
-		# up the origional.
+		# up the original.
 		my $bit = $_;
 		$bit="" unless defined( $bit );
 		$bit =~ s/[\\\|]/\\$&/g; 

--- a/perl_lib/EPrints/Search/Field.pm
+++ b/perl_lib/EPrints/Search/Field.pm
@@ -37,11 +37,11 @@ A search field has four key parameters:
 
 =item match=IN
 
-Treat the value as a list of whitespace-seperated words. Search for
+Treat the value as a list of whitespace-separated words. Search for
 each one in the full-text index.
 
 In the case of subjects, match these subject ids or the those of any
-of their decendants in the subject tree.
+of their descendants in the subject tree.
 
 =item match=EQ (equal)
 
@@ -54,7 +54,7 @@ If the value is an empty string then search for fields which are
 empty, as oppose to skipping this search field.
 
 In the case of subjects, match the specified subjects, but not their
-decendants.
+descendants.
 
 =item match=SET
 

--- a/perl_lib/EPrints/Sword/DepositClient.pm
+++ b/perl_lib/EPrints/Sword/DepositClient.pm
@@ -78,7 +78,7 @@ sub get_file_from_uri {
 
         my $ua = get_user_agent(undef);
 
-        open(FILE, ">", "$file" ) or die('cant open input file');
+        open(FILE, ">", "$file" ) or die("can't open input file");
         binmode FILE;
 
         my $h;
@@ -295,7 +295,7 @@ sub deposit_file {
 
 	return undef if (!defined $url);
 
-	open(FILE, "$filepath" ) or die('cant open input file');
+	open(FILE, "$filepath" ) or die("can't open input file");
 	binmode FILE;
 
 	my $ua = get_user_agent();

--- a/perl_lib/EPrints/Update/Views.pm
+++ b/perl_lib/EPrints/Update/Views.pm
@@ -130,7 +130,7 @@ Show items that have no value(s) for the selected field.
 
 =item cloud
 
-Render a "Tag Cloud" of links, where the individual links are scaled by their frequency of occurence.
+Render a "Tag Cloud" of links, where the individual links are scaled by their frequency of occurrence.
 
 =item cloudmin = 80, cloudmax = 200
 

--- a/perl_lib/EPrints/Utils.pm
+++ b/perl_lib/EPrints/Utils.pm
@@ -1363,7 +1363,7 @@ sub js_string
 # EPrints::Utils::process_parameters( $params, $defaults );
 #  for each key in the hash ref $defaults, if $params->{$key} is not set
 #  then it's set to the default from the $defaults hash.
-#  Also warns if unknown paramters were passed.
+#  Also warns if unknown parameters were passed.
 
 sub process_parameters($$)
 {

--- a/perl_lib/File/BOM.pm
+++ b/perl_lib/File/BOM.pm
@@ -234,7 +234,7 @@ If the file doesn't contain a BOM, $default_mode is used instead. Hence:
 Opens my_file.txt for reading in an appropriate encoding found from the BOM in
 that file, or as a UTF-8 file if none is found.
 
-In the absense of a $default_mode argument, the following 2 calls should be equivalent:
+In the absence of a $default_mode argument, the following 2 calls should be equivalent:
 
     open_bom(FH, 'no_bom.txt');
 
@@ -630,7 +630,7 @@ BOM being applied to the position parameter. Thus:
 
 =head2 Telling
 
-In order to work correctly with seek(), tell() also returns a postion adjusted
+In order to work correctly with seek(), tell() also returns a position adjusted
 by the length of the BOM.
 
 =cut

--- a/perl_lib/File/Temp.pm
+++ b/perl_lib/File/Temp.pm
@@ -635,7 +635,7 @@ sub _replace_XX {
 }
 
 # Internal routine to force a temp file to be writable after
-# it is created so that we can unlink it. Windows seems to occassionally
+# it is created so that we can unlink it. Windows seems to occasionally
 # force a file to be readonly when written to certain temp locations
 sub _force_writable {
   my $file = shift;
@@ -1976,7 +1976,7 @@ sub unlink0 {
     # Make sure that the link count is zero
     # - Cygwin provides deferred unlinking, however,
     #   on Win9x the link count remains 1
-    # On NFS the link count may still be 1 but we cant know that
+    # On NFS the link count may still be 1 but we can't know that
     # we are on NFS
     return ( $fh[3] == 0 or $^O eq 'cygwin' ? 1 : 0);
 
@@ -2232,7 +2232,7 @@ simply examine the return value of C<safe_level>.
       } else {
         # Dont allow this on perl 5.005 or earlier
         if ($] < 5.006 && $level != STANDARD) {
-          # Cant do MEDIUM or HIGH checks
+          # Can't do MEDIUM or HIGH checks
           croak "Currently requires perl 5.006 or newer to do the safe checks";
         }
         # Check that we are allowed to change level

--- a/perl_lib/Filesys/DiskSpace.pm
+++ b/perl_lib/Filesys/DiskSpace.pm
@@ -132,27 +132,27 @@ sub df ($) {
     # Trying to inform the user...
     if ($^O eq 'solaris' || $^O eq 'dec_osf') {
       # Tested. No problem if syscall.ph is present.
-      warn "An error occured. statvfs failed. Did you run h2ph?\n";
+      warn "An error occurred. statvfs failed. Did you run h2ph?\n";
       $w = 2;
     }
     if ($^O eq 'linux' || $^O eq 'freebsd') {
       # Tested with linux 2.0.0 and 2.2.2
       # No problem if syscall.ph is present.
-      warn "An error occured. statfs failed. Did you run h2ph?\n";
+      warn "An error occurred. statfs failed. Did you run h2ph?\n";
     }
     if ($^O eq 'hpux') {
       if ($osvers == 9) {
 	# Tested. You have to change a line in syscall.ph.
-	warn "An error occured. statfs failed. Did you run h2ph?\n" .
+	warn "An error occurred. statfs failed. Did you run h2ph?\n" .
 	  "If you are using a hp9000s700, see the Df documentation\n";
       }
       elsif ($osvers == 10) {
 	# Tested. No problem if syscall.ph is present.
-	warn "An error occured. statvfs failed. Did you run h2ph?\n";
+	warn "An error occurred. statvfs failed. Did you run h2ph?\n";
       }
       else {
 	# Untested
-	warn "An error occured. df failed. Please, submit a bug report.\n";
+	warn "An error occurred. df failed. Please, submit a bug report.\n";
       }
       $w = 3;
     }
@@ -254,7 +254,7 @@ Fabien Tassin E<lt>fta@oleane.netE<gt>
 =head1 NOTES
 
 This module was formerly called File::Df. It has been renamed into
-Filesys::DiskSpace. It could have be Filesys::Df but unfortunatly
+Filesys::DiskSpace. It could have be Filesys::Df but unfortunately
 another module created in the meantime uses this name.
 
 Tested with Perl 5.003 under these systems :

--- a/perl_lib/JSON.pm
+++ b/perl_lib/JSON.pm
@@ -659,7 +659,7 @@ They are JSNO::backportPP and so on. JSON.pm should work as it did at all.
  ************************** CAUTION ********************************
  * This is 'JSON module version 2' and there are many differences  *
  * to version 1.xx                                                 *
- * Please check your applications useing old version.              *
+ * Please check your applications using old version.               *
  *   See to 'INCOMPATIBLE CHANGES TO OLD VERSION'                  *
  *******************************************************************
 
@@ -1044,7 +1044,7 @@ format as output, putting every array member or object/hash key-value pair
 into its own line, identing them properly.
 
 If C<$enable> is false, no newlines or indenting will be produced, and the
-resulting JSON text is guarenteed not to contain any C<newlines>.
+resulting JSON text is guaranteed not to contain any C<newlines>.
 
 This setting has no effect when decoding JSON texts.
 
@@ -1592,7 +1592,7 @@ The below methods are JSON::PP own methods, so when C<JSON> works
 with JSON::PP (i.e. the created object is a JSON::PP object), available.
 See to L<JSON::PP/JSON::PP OWN METHODS> in detail.
 
-If you use C<JSON> with additonal C<-support_by_pp>, some methods
+If you use C<JSON> with additional C<-support_by_pp>, some methods
 are available even with JSON::XS. See to L<USE PP FEATURES EVEN THOUGH XS BACKEND>.
 
    BEING { $ENV{PERL_JSON_BACKEND} = 'JSON::XS' }
@@ -1945,7 +1945,7 @@ To check the backend module, there are some methods - C<backend>, C<is_pp> and C
   $json->is_pp; # 0 or 1
 
 
-If you set an enviornment variable C<PERL_JSON_BACKEND>, The calling action will be changed.
+If you set an environment variable C<PERL_JSON_BACKEND>, The calling action will be changed.
 
 =over
 

--- a/perl_lib/JSON/backportPP.pm
+++ b/perl_lib/JSON/backportPP.pm
@@ -2021,7 +2021,7 @@ as key-value pairs have no inherent ordering in Perl.
 
 This setting has no effect when decoding JSON texts.
 
-If you want your own sorting routine, you can give a code referece
+If you want your own sorting routine, you can give a code reference
 or a subroutine name to C<sort_by>. See to C<JSON::PP OWN METHODS>.
 
 =head2 allow_nonref

--- a/perl_lib/MIME/Lite.pm
+++ b/perl_lib/MIME/Lite.pm
@@ -1416,9 +1416,9 @@ with set() or replace().  Returns the text of the field.
     $ml->get('Subject', 0);
 
 If the optional 0-based INDEX is given, then we return the INDEX'th
-occurence of field TAG.  Otherwise, we look at the context:
-In a scalar context, only the first (0th) occurence of the
-field is returned; in an array context, I<all> occurences are returned.
+occurrence of field TAG.  Otherwise, we look at the context:
+In a scalar context, only the first (0th) occurrence of the
+field is returned; in an array context, I<all> occurrences are returned.
 
 I<Warning:> this should only be used with non-MIME fields.
 Behavior with MIME fields is TBD, and will raise an exception for now.
@@ -1547,7 +1547,7 @@ sub preamble {
 =item replace TAG,VALUE
 
 I<Instance method.>
-Delete all occurences of fields named TAG, and add a new
+Delete all occurrences of fields named TAG, and add a new
 field with the given VALUE.  TAG is converted to all-lowercase.
 
 B<Beware> the special MIME fields (MIME-version, Content-*):
@@ -3203,7 +3203,7 @@ come with.
 The whole reason that version 3.0 was released was to ensure that MIME::Lite
 is up to date and patched. If you find an issue please report it.
 
-As far as I know MIME::Lite doesnt currently have any serious bugs, but my usage
+As far as I know MIME::Lite doesn't currently have any serious bugs, but my usage
 is hardly comprehensive.
 
 Having said that there are a number of open issues for me, mostly caused by the progress
@@ -3212,7 +3212,7 @@ interesting but non standard test framework. I'd like to change it over to using
 Test::More.
 
 Should tests fail please review the ./testout directory, and in any bug reports
-please include the output of the relevent file. This is the only redeeming feature
+please include the output of the relevant file. This is the only redeeming feature
 of not using Test::More that I can see.
 
 Bug fixes / Patches / Contribution are welcome, however I probably won't apply them

--- a/perl_lib/OLE/Storage_Lite.pm
+++ b/perl_lib/OLE/Storage_Lite.pm
@@ -496,7 +496,7 @@ sub _savePpsSetPnt2($$$)
       push @$raList, $aThis->[$iPos];
       $aThis->[$iPos]->{No} = $#$raList;
 
-#1.3.2 Devide a array into Previous,Next
+#1.3.2 Divide an array into Previous, Next
       $aThis->[$iPos]->{NextPps} = _savePpsSetPnt2(
             \@aNext, $raList, $rhInfo);
       $aThis->[$iPos]->{DirPps} = _savePpsSetPnt2($aThis->[$iPos]->{Child}, $raList, $rhInfo);
@@ -532,7 +532,7 @@ sub _savePpsSetPnt2s($$$)
       push @$raList, $aThis->[$iPos];
       $aThis->[$iPos]->{No} = $#$raList;
       my @aWk = @$aThis;
-#1.3.2 Devide a array into Previous,Next
+#1.3.2 Divide an array into Previous, Next
       my @aPrev = splice(@aWk, 0, $iPos);
       my @aNext = splice(@aWk, 1, $iCnt - $iPos -1);
       $aThis->[$iPos]->{PrevPps} = _savePpsSetPnt2(
@@ -571,7 +571,7 @@ sub _savePpsSetPnt($$$)
       push @$raList, $aThis->[$iPos];
       $aThis->[$iPos]->{No} = $#$raList;
       my @aWk = @$aThis;
-#1.3.2 Devide a array into Previous,Next
+#1.3.2 Divide an array into Previous, Next
       my @aPrev = splice(@aWk, 0, $iPos);
       my @aNext = splice(@aWk, 1, $iCnt - $iPos -1);
       $aThis->[$iPos]->{PrevPps} = _savePpsSetPnt(
@@ -610,7 +610,7 @@ sub _savePpsSetPnt1($$$)
       push @$raList, $aThis->[$iPos];
       $aThis->[$iPos]->{No} = $#$raList;
       my @aWk = @$aThis;
-#1.3.2 Devide a array into Previous,Next
+#1.3.2 Divide an array into Previous, Next
       my @aPrev = splice(@aWk, 0, $iPos);
       my @aNext = splice(@aWk, 1, $iCnt - $iPos -1);
       $aThis->[$iPos]->{PrevPps} = _savePpsSetPnt(
@@ -1559,7 +1559,7 @@ C<$raTime1st>, C<$raTime2nd> are array refs with ($iSec, $iMin, $iHour, $iDay, $
 $iSec means seconds, $iMin means minutes. $iHour means hours.
 $iDay means day. $iMon is month -1. $iYear is year - 1900.
 
-C<$raChild> is a array ref of children PPSs.
+C<$raChild> is an array ref of children PPSs.
 
 
 =head2 save()
@@ -1594,12 +1594,12 @@ Constructor.
 
 C<$sName> is a name of the PPS.
 
-C<$raTime1st>, C<$raTime2nd> is a array ref as
+C<$raTime1st>, C<$raTime2nd> is an array ref as
 ($iSec, $iMin, $iHour, $iDay, $iMon, $iYear).
 $iSec means seconds, $iMin means minutes. $iHour means hours.
 $iDay means day. $iMon is month -1. $iYear is year - 1900.
 
-C<$raChild> is a array ref of children PPSs.
+C<$raChild> is an array ref of children PPSs.
 
 
 =head1 OLE::Storage_Lite::PPS::File

--- a/perl_lib/ParaTools/DocParser/Standard.pm
+++ b/perl_lib/ParaTools/DocParser/Standard.pm
@@ -973,7 +973,7 @@ sub _is_num {
 	my $doc = join "\n", @_;
 	my ($one,$two,$thr) = (1,2,3);
 	my @num_refs;
-	# Chop upto 300 chars off the front until we get a 1.
+	# Chop up to 300 chars off the front until we get a 1.
 #warn "_is_num: \$doc = ".substr($doc,0,50);
 	while( $doc =~ s/^.*?\b($one(\.\s|\s{4}))//s ) {
 		my $ref_sect = $1.$doc;

--- a/perl_lib/Text/Unidecode.pm
+++ b/perl_lib/Text/Unidecode.pm
@@ -133,7 +133,7 @@ Unidecode's ability to transliterate is limited by two factors:
 
 So if you have Hebrew data
 that has no vowel points in it, then Unidecode cannot guess what
-vowels should appear in a pronounciation.
+vowels should appear in a pronunciation.
 S f y hv n vwls n th npt, y wn't gt ny vwls
 n th tpt.  (This is a specific application of the general principle
 of "Garbage In, Garbage Out".)
@@ -223,7 +223,7 @@ characters -- i.e., characters 0x0000 - 0x007F.
 
 All Unicode characters translate to a sequence of (any number of)
 characters that are newline ("\n") or in the range 0x0020-0x007E.  That
-is, no Unicode character translates to "\x01", for example.  (Altho if
+is, no Unicode character translates to "\x01", for example.  (Although if
 you have a "\x01" on input, you'll get a "\x01" in output.)
 
 =item *
@@ -263,7 +263,7 @@ no matter what the surrounding character are.
 
 The main reason I'm making Text::Unidecode work with only
 context-insensitive substitution is that it's fast, dumb, and
-straightforward enough to be feasable.  It doesn't tax my
+straightforward enough to be feasible.  It doesn't tax my
 (quite limited) knowledge of world languages.  It doesn't require
 me writing a hundred lines of code to get the Thai syllabification
 right (and never knowing whether I've gotten it wrong, because I

--- a/perl_lib/URI/URL.pm
+++ b/perl_lib/URI/URL.pm
@@ -144,7 +144,7 @@ sub query {
 		Carp::croak("$mess (you must call equery)");
 	    }
 	}
-	# Now it should be safe to unescape the string without loosing
+	# Now it should be safe to unescape the string without losing
 	# information
 	return uri_unescape($old);
     }

--- a/perl_lib/XML/DOM.pm
+++ b/perl_lib/XML/DOM.pm
@@ -4274,7 +4274,7 @@ sub parsefile
 
 		    # Load proxy settings from environment variables, i.e.:
 		    # http_proxy, ftp_proxy, no_proxy etc. (see LWP::UserAgent(3))
-		    # You need these to go thru firewalls.
+		    # You need these to go through firewalls.
 		    $LWP_USER_AGENT->env_proxy;
 		}
 		$ua = $LWP_USER_AGENT;

--- a/perl_lib/XML/DOM/Node.pod
+++ b/perl_lib/XML/DOM/Node.pod
@@ -56,7 +56,7 @@ completeness.
 
 Returns a string or undef, depending on the node type. This method is provided 
 for completeness. In other languages it saves the programmer an upcast.
-The value is either available thru some other method defined in the subclass, or
+The value is either available through some other method defined in the subclass, or
 else undef is returned. Here are the corresponding methods: 
 Attr::getValue, Text::getData, CDATASection::getData, Comment::getData, 
 ProcessingInstruction::getData.

--- a/perl_lib/XML/DOM/Parser.pod
+++ b/perl_lib/XML/DOM/Parser.pod
@@ -50,7 +50,7 @@ By default it will use a L<LWP::UserAgent> that is created as follows:
  $LWP_USER_AGENT->env_proxy;
 
 Note that env_proxy reads proxy settings from environment variables, which is what I need to
-do to get thru our firewall. If you want to use a different LWP::UserAgent, you can either set
+do to get through our firewall. If you want to use a different LWP::UserAgent, you can either set
 it globally with:
 
  XML::DOM::Parser::set_LWP_UserAgent ($my_agent);


### PR DESCRIPTION
Most of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>