### PR TITLE
Correct typo in _add_node_to_xml

### DIFF
--- a/perl_lib/EPrints/XML.pm
+++ b/perl_lib/EPrints/XML.pm
@@ -1094,7 +1094,7 @@ sub _add_node_to_xml
 			($element->parentNode())->insertAfter($node,$element);
 			return 1;
 		}
-		if ($match_type eq "disbale") {
+		if ($match_type eq "disable") {
 			$element->setAttribute("disabled",1);
 			$element->setAttribute("disabled_by",$id);
 			$node->setAttribute("required_by",$id);


### PR DESCRIPTION
Typo means alterations to XML (e.g. Bazaar package manipulation of workflow) may not have worked when using:
<blah operation="disable">
