### PR TITLE
Accents in repository name : no email

### DIFF
--- a/perl_lib/EPrints/Email.pm
+++ b/perl_lib/EPrints/Email.pm
@@ -29,6 +29,7 @@ package EPrints::Email;
 use MIME::Lite;
 use LWP::MediaTypes qw( guess_media_type );
 use Encode; # required for MIME-Header support
+use URI::Escape; # required for complex strings in reply-to 
 
 use strict;
 
@@ -265,7 +266,7 @@ sub build_email
 
 	if( defined $p{replyto_email} )
 	{
-		$mimemsg->attr( "Reply-to" => "$p{replyto_name} <$p{replyto_email}>" );
+		$mimemsg->attr( "Reply-to" => uri_escape($p{replyto_name})." <$p{replyto_email}>" );
 	}
 	$mimemsg->replace( "X-Mailer" => "EPrints http://eprints.org/" );
 


### PR DESCRIPTION
Context :
- my repository has accents in the name.
- i adapted a plugin (email_editors) to send a proof of deposit to the user who put a document

Problem : 
- email doesn't work

After debugging the Net::SMTP, the reply-to seemed to be the problem. The plugin puts the repo name as "reply-to name".
After adding uri_escape to it, it works. This in certainly a rule of smtp servers.

Hope it could help.
