### PR TITLE
media_width and media_height are not used

### DIFF
--- a/lib/defaultcfg/cfg.d/document_fields_automatic.pl
+++ b/lib/defaultcfg/cfg.d/document_fields_automatic.pl
@@ -1,5 +1,15 @@
-
-$c->{set_document_automatic_fields} = sub
-{
+$c->{set_document_automatic_fields} = sub {
 	my( $doc ) = @_;
+	#######
+	#
+	# Populate the media size values. TODO other media type
+	#
+	#######
+	if(($doc->value("format") eq "image") && defined($doc->value("main"))){
+		use Image::Size;
+		my $file_local_path = $doc->local_path . "/" . $doc->value("main");
+		my ($width, $height, $id) = imgsize( "$file_local_path" );
+		$doc->set_value("media_width", $width);
+		$doc->set_value("media_height", $height);
+	}
 };

--- a/lib/defaultcfg/cfg.d/document_fields_automatic.pl
+++ b/lib/defaultcfg/cfg.d/document_fields_automatic.pl
@@ -6,10 +6,10 @@ $c->{set_document_automatic_fields} = sub {
 	#
 	#######
 	if(($doc->value("format") eq "image") && defined($doc->value("main"))){
-		use Image::Size;
-		my $file_local_path = $doc->local_path . "/" . $doc->value("main");
-		my ($width, $height, $id) = imgsize( "$file_local_path" );
-		$doc->set_value("media_width", $width);
-		$doc->set_value("media_height", $height);
+	#	use Image::Size;
+	#	my $file_local_path = $doc->local_path . "/" . $doc->value("main");
+	#	my ($width, $height, $id) = imgsize( "$file_local_path" );
+	#	$doc->set_value("media_width", $width);
+	#	$doc->set_value("media_height", $height);
 	}
 };


### PR DESCRIPTION
I just realized that media_width and media_height are not used in document. it is a pity, because they can be used for test and eprints validation (like using a carousel, is the image of the right size?). Issue #411
TODO: add information for other media too.
