### PR TITLE
\C is deprecated in Perl 5.22

### DIFF
--- a/perl_lib/URI/Escape.pm
+++ b/perl_lib/URI/Escape.pm
@@ -202,7 +202,13 @@ sub uri_unescape {
 }
 
 sub escape_char {
-    return join '', @URI::Escape::escapes{$_[0] =~ /(\C)/g};
+ #    return join '', @URI::Escape::escapes{$_[0] =~ /(\C)/g};
+ if (utf8::is_utf8($_[0])) {
+  my $s = $_[0];
+  utf8::encode($s);
+  unshift(@_, $s);
+ }
+ return join '', @URI::Escape::escapes{$_[0] =~ /(.)/sg};
 }
 
 1;


### PR DESCRIPTION
[apply patch from RT#96941 to fix new "\C is deprecated in regex"](https://github.com/libwww-perl/uri/commit/7e03cdd3e5d25df5556a36dbfcd5d6cbcd676afb) Propose this solution to avoid the message: "\C is deprecated in regex". I think this is just a temporary solution, best would be to upgrade the URI library, or, even better, remove it from the core and make it a dependence.
