### PR TITLE
Fix Arxiv BibTeX name processing

### DIFF
--- a/perl_lib/BibTeX/Parser/Entry.pm
+++ b/perl_lib/BibTeX/Parser/Entry.pm
@@ -135,7 +135,7 @@ sub _split_author_field {
 		$buffer = "";
 	    } elsif ( $2 =~ /\{/ ) {
 		$buffer .= $match . "{";
-		if ( $field =~ /\G (.* \}?)/cgx ) {
+		if ( $field =~ /\G (.*? \})/cgx ) {
 		    $buffer .= $1;
 		} else {
 		    die "Missing closing brace at " . substr( $field, pos $field, 10 );

--- a/perl_lib/BibTeX/Parser/Entry.pm
+++ b/perl_lib/BibTeX/Parser/Entry.pm
@@ -135,7 +135,7 @@ sub _split_author_field {
 		$buffer = "";
 	    } elsif ( $2 =~ /\{/ ) {
 		$buffer .= $match . "{";
-		if ( $field =~ /\G (.* \})/cgx ) {
+		if ( $field =~ /\G (.* \}?)/cgx ) {
 		    $buffer .= $1;
 		} else {
 		    die "Missing closing brace at " . substr( $field, pos $field, 10 );


### PR DESCRIPTION
Change BibTeX::Entry split_author_field to handle BibTeX format from http://adsabs.harvard.edu/  where authors listed like {{surname}, A.~B. and {s{\"u}rname-two}, C.~D.~E.} - make the pattern matching non-greedy so it doesn't ingest the whole string as one name.