### PR TITLE
Default to show the plugin in staff list

### DIFF
--- a/perl_lib/EPrints/Plugin/Export/MultilineCSV.pm
+++ b/perl_lib/EPrints/Plugin/Export/MultilineCSV.pm
@@ -23,6 +23,7 @@ sub new
 	$self->{visible} = "staff";
 	$self->{suffix} = ".csv";
 	$self->{mimetype} = "text/csv; charset=utf-8";
+	$self->{advertise} = 1;  #to override the advertise=0 set in SUPER::new
 	
 	return $self;
 }


### PR DESCRIPTION
Set the advertise option to 1 to show the plugin in the staff export list by default as this is now otherwise hidden by Export::Grid::new