### PR TITLE
Add error messages in Event descriptions

### DIFF
--- a/perl_lib/EPrints/DataObj/EventQueue.pm
+++ b/perl_lib/EPrints/DataObj/EventQueue.pm
@@ -290,8 +290,9 @@ sub _execute
 	my $rc = eval { $plugin->$action( @params ) };
 	if( $@ )
 	{
-		$self->message( "error", $xml->create_text_node( "Error during execution: $@" ) );
-		$self->set_value( "description", $@ );
+		my $error_message = $@;
+		$self->message( "error", $xml->create_text_node( "Error during execution: $error_message" ) );
+		$self->set_value( "description", $error_message );
 		return EPrints::Const::HTTP_INTERNAL_SERVER_ERROR;
 	}
 


### PR DESCRIPTION
$@ was getting reset in the $self->message call so not being set on the event description.  Capture message value early then use captured value to write to both $self->message and set_value
Fixes #398 