### PR TITLE
add UTF-8 to MySQL DSN

### DIFF
--- a/perl_lib/EPrints/Database.pm
+++ b/perl_lib/EPrints/Database.pm
@@ -161,6 +161,7 @@ sub build_connection_string
         {
                 $dsn.= ";mysql_socket=".$params{dbsock};
         }
+        $dsn.= ";mysql_enable_utf8=1";
         return $dsn;
 }
 


### PR DESCRIPTION
setting it before connecting is potentially better than relying on SET NAMES or similar afterwards