### PR TITLE
add an XML parser that parses fragments

### DIFF
--- a/perl_lib/EPrints/XML.pm
+++ b/perl_lib/EPrints/XML.pm
@@ -129,6 +129,18 @@ sub parse_string
 	return parse_xml_string( $string );
 }
 
+=item $doc_frag = parse_frag_string( $string )
+
+Parse $string and return it as a new DOM Document Fragment.
+
+=cut
+
+sub parse_frag_string
+{
+	my( $self, $string ) = @_;
+	return parse_xml_frag_string( $string );
+}
+
 =item $doc = $xml->parse_file( $filename, %opts )
 
 Returns an XML document parsed from the file called $filename.

--- a/perl_lib/EPrints/XML/DOM.pm
+++ b/perl_lib/EPrints/XML/DOM.pm
@@ -160,6 +160,15 @@ sub _parse_url
 	return $doc;
 }
 
+sub parse_xml_frag_string
+{
+	# FIXME: bet this doesn't like missing <?xml?> and stuff
+	my $doc = parse_xml_string( @_ );
+	my $frag = XML::DOM::Document->new->createDocumentFragment;
+	$frag->cloneChildren( $doc, 1 );
+	return $frag;
+}
+
 sub parse_xml
 {
 	my( $file, $basepath, $no_expand ) = @_;

--- a/perl_lib/EPrints/XML/GDOME.pm
+++ b/perl_lib/EPrints/XML/GDOME.pm
@@ -58,6 +58,19 @@ $EPrints::XML::LIB_LEN = length("XML::GDOME::");
 		return $f;
 	};
 
+sub parse_xml_frag_string
+{
+	# FIXME: bet this doesn't like missing <?xml?> and stuff
+	my $doc = parse_xml_string( @_ );
+
+	my $frag = XML::GDOME->createDocument->createDocumentFragment;
+	for($doc->childNodes)
+	{
+		$frag->appendChild( $_->cloneNode( 1 ) );
+	}
+	return $frag;
+}
+
 sub parse_xml_string
 {
 	my( $string ) = @_;

--- a/perl_lib/EPrints/XML/LibXML.pm
+++ b/perl_lib/EPrints/XML/LibXML.pm
@@ -95,6 +95,21 @@ sub _parse_url
 	return $doc;
 }
 
+=item $doc_frag = parse_xml_frag_string( $string )
+
+Parse $string and return it as a new DOM Document Fragment.
+
+=cut
+
+sub parse_xml_frag_string
+{
+	my( $string ) = @_;
+
+	my $frag = $PARSER->parse_balanced_chunk( $string );
+
+	return $frag;
+}
+
 =item $doc = parse_xml( $filename [, $basepath [, $no_expand]] )
 
 Parse $filename and return it as a new DOM document.


### PR DESCRIPTION
Sometimes it's handy to parse a chunk of text into an XML Document Fragment, instead of a full, heavy-weight XML Document.

This implements that for LibXML, and has tentative implementations for DOM and GDOME.  Do many repositories out there even use DOM or GDOME?