### PR TITLE
EPrints::DOI may return undef

### DIFF
--- a/lib/cfg.d/rdf_triples_bibo.pl
+++ b/lib/cfg.d/rdf_triples_bibo.pl
@@ -178,10 +178,13 @@ $c->add_dataset_trigger( "eprint", EP_TRIGGER_RDF, sub {
 	if( $eprint->dataset->has_field( "id_number" ) && $eprint->is_set( "id_number" ) )
 	{
 		my $doi = EPrints::DOI->parse( $eprint->get_value( "id_number" ) );
-		$o{"graph"}->add(
-			  subject => $eprint_uri,
-			predicate => "owl:sameAs",
-			   object => "<$doi>" );
+		if( $doi )
+		{
+			$o{"graph"}->add(
+				  subject => $eprint_uri,
+				predicate => "owl:sameAs",
+				   object => "<$doi>" );
+		}
 	}
 
 	# PageRange


### PR DESCRIPTION
If id_number is not a DOI, `EPrints::DOI` will return undef, resulting in an empty element + warning.