### PR TITLE
Handle empty-string in URL type

### DIFF
--- a/perl_lib/EPrints/Extras.pm
+++ b/perl_lib/EPrints/Extras.pm
@@ -250,7 +250,7 @@ sub render_related_url
 	{
 		my $li = $session->make_element( "li" );
 		my $link = $session->render_link( $row->{url} );
-		if( defined $row->{type} )
+		if( EPrints::Utils::is_set( $row->{type} ) )
 		{
 			$link->appendChild( $fmap->{type}->render_single_value( $session, $row->{type} ) );
 		}


### PR DESCRIPTION
An empty string in the related_url_type was causing the URL to be rendered with the (ugly) `UNSPECIFIED` rather than the URL itself.