### PR TITLE
Consider document security when adding to index

### DIFF
--- a/perl_lib/EPrints/MetaField/Subobject.pm
+++ b/perl_lib/EPrints/MetaField/Subobject.pm
@@ -251,6 +251,9 @@ sub get_index_codes_basic
 
 	# only know how to get index codes out of documents
 	return( [], [], [] ) if !$doc->isa( "EPrints::DataObj::Document" );
+	
+	# only generate/use full-text index for public documents
+	return( [], [], [] ) if !$doc->is_public;
 
 	# we only supply index codes for proper documents
 	return( [], [], [] ) if $doc->has_relation( undef, "isVolatileVersionOf" );

--- a/perl_lib/EPrints/MetaField/Subobject.pm
+++ b/perl_lib/EPrints/MetaField/Subobject.pm
@@ -252,9 +252,6 @@ sub get_index_codes_basic
 	# only know how to get index codes out of documents
 	return( [], [], [] ) if !$doc->isa( "EPrints::DataObj::Document" );
 	
-	# only generate/use full-text index for public documents
-	return( [], [], [] ) if !$doc->is_public;
-
 	# we only supply index codes for proper documents
 	return( [], [], [] ) if $doc->has_relation( undef, "isVolatileVersionOf" );
 
@@ -279,6 +276,9 @@ sub get_index_codes_basic
 		}
 	}
 
+	# if the document is not public, don't add the indexcodes to the fulltext index database table
+	return( [], [], [] ) unless $doc->exists_and_set( "security" ) && $doc->value( "security" ) eq "public";
+	
 	return( [], [], [] ) unless defined $indexcodes_doc;
 
 	my $data = "";

--- a/perl_lib/EPrints/MetaField/Subobject.pm
+++ b/perl_lib/EPrints/MetaField/Subobject.pm
@@ -251,7 +251,7 @@ sub get_index_codes_basic
 
 	# only know how to get index codes out of documents
 	return( [], [], [] ) if !$doc->isa( "EPrints::DataObj::Document" );
-	
+
 	# we only supply index codes for proper documents
 	return( [], [], [] ) if $doc->has_relation( undef, "isVolatileVersionOf" );
 


### PR DESCRIPTION
Don't add full-text index terms if the document isn't public.

See also https://github.com/eprints/eprints3.4/pull/44