### PR TITLE
allow special chars in advanced search for names

### DIFF
--- a/perl_lib/EPrints/MetaField/Name.pm
+++ b/perl_lib/EPrints/MetaField/Name.pm
@@ -246,7 +246,7 @@ sub get_search_conditions
 	$v2 =~ s/([A-Z])/ $1/g;
 
 	# remove not a-z characters (except , and ')
-	$v2 =~ s/[^a-z,']/ /ig;
+	$v2 =~ s/[^[:alnum:],']/ /ig;
 
 	my( $family, $given ) = split /\s*,\s*/, $v2;
 	my @freetexts = ();


### PR DESCRIPTION
Allows special chars like Č in contributor name fields in advanced search. Related to #13 