### PR TITLE
Add the optional attributes of resumptionToken

### DIFF
--- a/lib/static/oai2.xsl
+++ b/lib/static/oai2.xsl
@@ -40,7 +40,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
   Not Done
     The 'about' section of 'record'
     The 'compession' part of 'identify'
-    The optional attributes of 'resumptionToken'
     The optional 'setDescription' container of 'set'
 
   All the links just link to oai_dc versions of records.
@@ -530,6 +529,15 @@ p.intro {
 <xsl:template match="oai:resumptionToken">
    <p>There are more results.</p>
    <table class="values">
+      <xsl:if test="@expirationDate">
+         <tr><td class="key">expirationDate</td><td class="value"><xsl:value-of select="@expirationDate"/></td></tr>
+      </xsl:if>
+      <xsl:if test="@completeListSize">
+         <tr><td class="key">completeListSize</td><td class="value"><xsl:value-of select="@completeListSize"/></td></tr>
+      </xsl:if>
+      <xsl:if test="@completeListSize">
+         <tr><td class="key">cursor</td><td class="value"><xsl:value-of select="@cursor"/></td></tr>
+      </xsl:if>
      <tr><td class="key">resumptionToken:</td>
      <td class="value"><xsl:value-of select="."/>
 <xsl:text> </xsl:text>


### PR DESCRIPTION
By displaying these optional attributes of resumptionToken the xsl performs better in the general case, including the xsl's downstream usage in OJS.